### PR TITLE
Progress

### DIFF
--- a/src/Application.ts
+++ b/src/Application.ts
@@ -48,6 +48,7 @@ import { AuthorizationTest } from './middleware/AuthorizationTest';
 import { Version } from './version/version';
 import io from 'socket.io';
 import * as path from "path";
+import { MaintenanceMiddleware } from './middleware/maintenance.middleware';
 
 export class Application extends AbstractApplication {
     static VERSION_FILENAME = 'version.json';
@@ -115,6 +116,7 @@ export class Application extends AbstractApplication {
             RequestBuilder,
             Compression,
             MethodOverride,
+            MaintenanceMiddleware,
             AttachDatabaseConnection,
             Session,
             CORS,

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -38,7 +38,7 @@ const config = convict({
     doc: 'Application maintenance mode',
     format: Boolean,
     default: false,
-    env: MAINTENANCE_MODE
+    env: "MAINTENANCE_MODE"
   },
 
   // Server bind parameters.

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -34,6 +34,13 @@ const config = convict({
     env: 'NODE_ENV'
   },
 
+  maintenance_mode: {
+    doc: 'Application maintenance mode',
+    format: Boolean,
+    default: false,
+    env: MAINTENANCE_MODE
+  },
+
   // Server bind parameters.
   listen: {
     ip: {

--- a/src/controllers/backups/backup.controller.ts
+++ b/src/controllers/backups/backup.controller.ts
@@ -26,6 +26,8 @@ import { app } from "../../fonaments/abstract-application";
 import { Backup } from "../../backups/backup";
 import { ResponseBuilder } from "../../fonaments/http/response-builder";
 import { Request } from "express";
+import { Progress } from "../../fonaments/http/progress/progress";
+import { SocketManager } from "../../sockets/socket-manager";
 
 export class BackupController extends Controller {
     protected _backupService: BackupService;
@@ -63,10 +65,22 @@ export class BackupController extends Controller {
      * @param response 
      */
     public async store(request: Request): Promise<ResponseBuilder> {
-        //TODO: Authorization
-        const backup: Backup = await this._backupService.create(request.inputs.get('comment'));
+        const socket: SocketManager = SocketManager.init(request.body.socketid, 'backups:create')
 
-        return ResponseBuilder.buildResponse().status(201).body(backup);
+        //TODO: Authorization
+        const progress: Progress<Backup> = this._backupService.create(request.inputs.get('comment'))
+            .on('start', (payload) => {
+                socket.event(payload);
+            })
+            .on('event', (payload) => {
+                socket.event(payload);
+            })
+            .on('end', async (payload) => {
+                await this._backupService.applyRetentionPolicy();
+                socket.end(payload);
+            });
+
+        return ResponseBuilder.buildResponse().status(201).body(progress.response);
     }
 
     /**
@@ -76,10 +90,21 @@ export class BackupController extends Controller {
      * @param response 
      */
     public async restore(request: Request): Promise<ResponseBuilder> {
+        const socket: SocketManager = SocketManager.init(request.body.socketid, 'backups:restore')
+
         //TODO: Authorization
         const backup: Backup = await this._backupService.findOne(parseInt(request.params.backup));
 
-        await this._backupService.restore(backup);
+        this._backupService.restore(backup)
+            .on('start', (payload) => {
+                socket.event(payload);
+            })
+            .on('event', (payload) => {
+                socket.event(payload);
+            })
+            .on('end', async (payload) => {
+                socket.end(payload);
+            });;
 
         return ResponseBuilder.buildResponse().status(201).body(backup);
     }

--- a/src/controllers/backups/backup.controller.ts
+++ b/src/controllers/backups/backup.controller.ts
@@ -95,6 +95,8 @@ export class BackupController extends Controller {
         //TODO: Authorization
         const backup: Backup = await this._backupService.findOne(parseInt(request.params.backup));
 
+        this._app.config.set('maintenance_mode', true);
+
         this._backupService.restore(backup)
             .on('start', (payload) => {
                 socket.event(payload);
@@ -104,6 +106,7 @@ export class BackupController extends Controller {
             })
             .on('end', async (payload) => {
                 socket.end(payload);
+                this._app.config.set('maintenance_mode', false);
             });;
 
         return ResponseBuilder.buildResponse().status(201).body(backup);

--- a/src/fonaments/exceptions/service-unavailable.exception.ts
+++ b/src/fonaments/exceptions/service-unavailable.exception.ts
@@ -1,0 +1,10 @@
+import { HttpException } from "./http/http-exception";
+
+export class ServiceUnavailableException extends HttpException {
+    constructor() {
+        super();
+        this.status = 503;
+        this.info = 'Service Unavailable';
+        this.message = this.info;
+    }
+}

--- a/src/fonaments/http/progress/progress-event.ts
+++ b/src/fonaments/http/progress/progress-event.ts
@@ -1,0 +1,45 @@
+import { Responsable } from "../../contracts/responsable";
+
+export class ProgressEvent implements Responsable {
+    protected _steps: number;
+    protected _currentStep: number;
+    
+    protected _message: string;
+    protected _status: number;
+
+    constructor(steps: number) {
+        this._steps = steps;
+        this._currentStep = 1;
+        this._message = null;
+        this._status = 200;
+    }
+
+    get percentage(): number {
+        return Math.floor((this._currentStep * 100) / this._steps);
+    }
+
+    toResponse(): Object {
+        return {
+            step: this._currentStep,
+            steps: this._steps,
+            percentage: this.percentage,
+            message: this._message,
+            status: this._status
+        }
+    }
+
+    public setStep(step: number, status: number = 200, message?: string): this {
+        this._currentStep = step <= this._steps? step: this._steps;
+        this._status = status;
+        if (message) {
+            this._message = message;
+        }
+
+        return this;
+    }
+
+    public incrementStep(status: number = 200, message?: string): this {
+        this._currentStep = this._currentStep + 1;
+        return this.setStep(this._currentStep, status, message);
+    }
+}

--- a/src/fonaments/http/progress/progress.ts
+++ b/src/fonaments/http/progress/progress.ts
@@ -1,0 +1,28 @@
+import { EventEmitter } from "typeorm/platform/PlatformTools";
+
+export class Progress<T> {
+    protected _response: T;
+    protected _eventScope: string
+    protected _eventEmitter: EventEmitter;
+
+    constructor(response: T, eventScope: string) {
+        this._response = response;
+        this._eventScope = eventScope;
+
+        this._eventEmitter = new EventEmitter();
+    }
+
+    get response(): T {
+        return this._response;
+    }
+
+    public emit(event: string, args: object): boolean {
+        return this._eventEmitter.emit(this._eventScope + ':' + event, args);
+    }
+
+    public on(event: string, listener: (...args: any[]) => void): this {
+        this._eventEmitter.on(this._eventScope + ':' + event, listener);
+        return this;
+    }
+
+}

--- a/src/fonaments/http/response-builder.ts
+++ b/src/fonaments/http/response-builder.ts
@@ -64,6 +64,10 @@ export class ResponseBuilder {
         return this;
     }
 
+    public toJSON(): object {
+        return this._payload;
+    }
+
     protected buildResponse(payload: any): Object {
         if (payload instanceof Error) {
             return this.buildErrorResponse(payload);

--- a/src/middleware/maintenance.middleware.ts
+++ b/src/middleware/maintenance.middleware.ts
@@ -1,0 +1,14 @@
+import { Middleware } from "../fonaments/http/middleware/Middleware";
+import { Request, Response, NextFunction } from "express";
+import { ServiceUnavailableException } from "../fonaments/exceptions/service-unavailable.exception";
+
+export class MaintenanceMiddleware extends Middleware {
+    public handle(req: Request, res: Response, next: NextFunction) {
+        if (this.app.config.get('maintenance_mode')) {
+            return next(new ServiceUnavailableException())
+        }
+        
+        return next();
+    }
+    
+}

--- a/src/sockets/socket-manager.ts
+++ b/src/sockets/socket-manager.ts
@@ -1,0 +1,45 @@
+import io from 'socket.io';
+import { app } from '../fonaments/abstract-application';
+import { Application } from '../Application';
+import { ResponseBuilder } from '../fonaments/http/response-builder';
+
+export class SocketManager {
+    protected _socket: io.Socket;
+    protected _scope: string;
+    protected _connected: boolean;
+
+    get socket(): io.Socket {
+        return this._socket;
+    }
+
+    protected constructor(socketId: string, scope: string) {
+        if (app<Application>().socketio) {
+            this._socket = app<Application>().socketio.sockets.connected[socketId];
+        }
+        this._scope = scope;
+
+        if (this._socket) {
+            this._connected = true;
+        }
+    }
+
+    public static init(socketId: string, scope: string): SocketManager {
+        const instance = new SocketManager(socketId, scope)
+        return instance;
+    }
+    
+    public event(data: any, status: number = 200) {
+        this.emit(this._scope + ':event', data, status);
+    }
+  
+    public end(data: any, status: number = 200) {
+        this.emit(this._scope + ":end", data, status);
+    }
+
+    protected emit(scope: string, data: any, status: number) {
+        const payload: object = ResponseBuilder.buildResponse().status(status).body(data).toJSON();
+        if (this._socket) {
+            this._socket.emit(this._scope, payload);
+        }
+    }
+}

--- a/tests/Unit/backups/backup.service.spec.ts
+++ b/tests/Unit/backups/backup.service.spec.ts
@@ -53,7 +53,7 @@ describe(describeName('BackupService tests'), async() => {
     });
 
     it('create should create a backup', async() => {
-        const backup: Backup = await service.create();
+        const backup: Backup = await new Backup().create(service.config.data_dir);
 
         expect(backup.exists()).to.be.true;
     });

--- a/tests/Unit/middlewares/maintenance.middleware.spec.ts
+++ b/tests/Unit/middlewares/maintenance.middleware.spec.ts
@@ -1,0 +1,20 @@
+import { describeName, testSuite } from "../../mocha/global-setup";
+import { Application } from "../../../src/Application";
+import request = require("supertest");
+import { _URL } from "../../../src/fonaments/http/router/router.service";
+
+let app: Application;
+
+describe(describeName('Maintenance middleware test'), () => {
+    beforeEach(async () => {
+        app = testSuite.app;
+    });
+
+    it.only('should return 503 if the application is in maintenance mode', async() => {
+        app.config.set('maintenance_mode', true);
+
+        await request(app.express)
+            .post(_URL().getURL('versions.show'))
+            .expect(503)
+    });
+})

--- a/tests/e2e/api/backups.e2e.spec.ts
+++ b/tests/e2e/api/backups.e2e.spec.ts
@@ -73,9 +73,8 @@ describe(describeName('Backup E2E tests'), () => {
         it('admin user should see backup index', async () => {
             const backupService: BackupService = await app.getService<BackupService>(BackupService.name);
 
-            const backup1: Backup = await backupService.create();
-            await sleep(1000);
-            const backup2: Backup = await backupService.create();
+            const backup1: Backup = await new Backup().create(backupService.config.data_dir);
+            const backup2: Backup = await new Backup().create(backupService.config.data_dir);
 
             return await request(app.express)
                 .get(_URL().getURL('backups.index'))
@@ -91,7 +90,7 @@ describe(describeName('Backup E2E tests'), () => {
 
         it('guest user should not see a backup', async () => {
             const backupService: BackupService = await app.getService<BackupService>(BackupService.name);
-            const backup: Backup = await backupService.create();
+            const backup: Backup = await new Backup().create(backupService.config.data_dir);
 
             await request(app.express)
                 .get(_URL().getURL('backups.show', {backup: backup.id}))
@@ -100,7 +99,7 @@ describe(describeName('Backup E2E tests'), () => {
 
         it('regular user should not see a backup', async () => {
             const backupService: BackupService = await app.getService<BackupService>(BackupService.name);
-            const backup: Backup = await backupService.create();
+            const backup: Backup = await new Backup().create(backupService.config.data_dir);
 
             await request(app.express)
                 .get(_URL().getURL('backups.show', {backup: backup.id}))
@@ -110,7 +109,7 @@ describe(describeName('Backup E2E tests'), () => {
 
         it('admin user should see a backup', async () => {
             const backupService: BackupService = await app.getService<BackupService>(BackupService.name);
-            const backup: Backup = await backupService.create();
+            const backup: Backup = await new Backup().create(backupService.config.data_dir);
 
             await request(app.express)
                 .get(_URL().getURL('backups.show', {backup: backup.id}))
@@ -166,8 +165,7 @@ describe(describeName('Backup E2E tests'), () => {
         let backup: Backup;
 
         beforeEach(async() => {
-            const backupService: BackupService = await app.getService<BackupService>(BackupService.name);
-            backup = await backupService.create();
+            backup = await new Backup().create(backupService.config.data_dir);
         });
 
         it('guest user should not destroy a backup', async () => {


### PR DESCRIPTION
Some requests (like `backup` creation or restore) may take some time. Thus, a `request` should not wait until the process is finished. In order to avoid that situation, now this kind of request returns the response as soon as the backup metadata is generated (which is a quick operation) and send `progress events` using `websockets` for the database export and import.
