### PR TITLE
Solved problem with ER_LOCK_WAIT_TIMEOUT in database.

### DIFF
--- a/src/database/database-manager.ts
+++ b/src/database/database-manager.ts
@@ -85,17 +85,6 @@ export class DatabaseManager {
         done();
     };
 
-    public lockTableCon(table: string, where: string, done: () => void) {
-        this.getQuery().query("SELECT count(*) from " + table + " " + where + " FOR UPDATE;", (error, result) => {
-            if (error)
-                logger.debug("DATABASE ERROR IN LOCK TABLE : " + error);
-            else
-                logger.debug("TABLE " + table + " LOCKED");
-        });
-        done();
-    };
-
-
     public startTX(cn: Query, done: () => void) {
         cn.query("START TRANSACTION;", (error, result) => {
             if (error)

--- a/src/models/policy/PolicyRule.ts
+++ b/src/models/policy/PolicyRule.ts
@@ -646,22 +646,15 @@ export class PolicyRule extends Model {
 
     //Update policy_r from user
     public static updatePolicy_r_Group(firewall, oldgroup, newgroup, id, callback) {
+        return new Promise((resolve, reject) => {
+            db.get((error, connection) => {
+                if (error) return reject(error);
 
-        db.get((error, connection) => {
-            if (error)
-                callback(error, null);
-
-            var sql = 'UPDATE ' + tableName + ' SET ' +
-                'idgroup = ' + connection.escape(newgroup) + ' ' +
-                ' WHERE id = ' + id + " and firewall=" + firewall;
-            if (oldgroup !== null)
-                sql += "  AND idgroup=" + oldgroup;
-            logger.debug(sql);
-            connection.query(sql, async (error, result) => {
-                if (error) {
-                    logger.error(error);
-                    callback(error, null);
-                } else {
+                var sql = `UPDATE ${tableName} SET
+                    idgroup=${connection.escape(newgroup)} WHERE id=${id} and firewall=${firewall}`;
+                if (oldgroup !== null) sql += ` AND idgroup=${oldgroup}`;
+                connection.query(sql, async (error, result) => {
+                    if (error) return reject(error);
                     if (result.affectedRows > 0) {
                         if (oldgroup !== null) {
                             await modelEventService.emit('update', PolicyRule, {
@@ -675,98 +668,84 @@ export class PolicyRule extends Model {
                                 firewall: firewall
                             })
                         }
-                        callback(null, { "result": true });
+                        resolve({ "result": true });
                     } else
-                        callback(null, { "result": false });
-                }
+                        resolve({ "result": false });
+                });
             });
         });
     };
     //Update policy_r Style
-    public static updatePolicy_r_Style(firewall, id, type, style, callback) {
+    public static updatePolicy_r_Style(firewall, id, type, style) {
+        return new Promise((resolve, reject) => {
+            db.get((error, connection) => {
+                if (error) return reject(error);
 
-        db.get((error, connection) => {
-            if (error)
-                callback(error, null);
-
-            var sql = 'UPDATE ' + tableName + ' SET ' +
-                'style = ' + connection.escape(style) + ' ' +
-                ' WHERE id = ' + connection.escape(id) + " and firewall=" + connection.escape(firewall) + " AND type=" + connection.escape(type);
-            connection.query(sql, async (error, result) => {
-                if (error) {
-                    logger.error(error);
-                    callback(error, null);
-                } else {
+                var sql = `UPDATE ${tableName} SET
+                    style=${connection.escape(style)}
+                    WHERE id=${connection.escape(id)} and firewall=${connection.escape(firewall)} AND type=${connection.escape(type)}`;
+                connection.query(sql, async (error, result) => {
+                    if (error) return reject(error);
                     if (result.affectedRows > 0) {
                         await modelEventService.emit('update', PolicyRule, {
                             id: id,
                             firewall: firewall,
                             type: type
                         })
-                        callback(null, { "result": true });
+                        resolve({ "result": true });
                     } else
-                        callback(null, { "result": false });
-                }
+                        resolve({ "result": false });
+                });
             });
         });
     }
 
     //Update policy_r Active
-    public static updatePolicy_r_Active(firewall, id, type, active, callback) {
+    public static updatePolicy_r_Active(firewall, id, type, active) {
+        return new Promise((resolve, reject) => {
+            db.get((error, connection) => {
+                if (error) return reject(error);
 
-        db.get((error, connection) => {
-            if (error)
-                callback(error, null);
+                var sql = `UPDATE ${tableName} SET active=${active}
+                    WHERE id=${id} and firewall=${firewall} AND type=${type}
+                    AND special=0`; // We can not enable/disable special rules.
 
-            var sql = `UPDATE ${tableName} SET active=${active}
-			WHERE id=${id} and firewall=${firewall} AND type=${type}
-			AND special=0`; // We can not enable/disable special rules.
-
-            connection.query(sql, async (error, result) => {
-                if (error) {
-                    logger.error(error);
-                    callback(error, null);
-                } else {
+                connection.query(sql, async (error, result) => {
+                    if (error) return reject(error);
                     if (result.affectedRows > 0) {
                         await modelEventService.emit('update', PolicyRule, {
                             id: id,
                             firewall: firewall,
                             type: type
-                        })
-                        callback(null, { "result": true });
+                        });
+                        resolve({ "result": true });
                     } else
-                        callback(null, { "result": false });
-                }
+                        resolve({ "result": false });
+                });
             });
-
         });
     };
 
     //Update policy_r from user
-    public static updatePolicy_r_GroupAll(firewall, idgroup, callback) {
+    public static updatePolicy_r_GroupAll(firewall, idgroup) {
+        return new Promise((resolve, reject) => {
+            db.get((error, connection) => {
+                if (error) return reject(error);
 
-        db.get((error, connection) => {
-            if (error)
-                callback(error, null);
+                var sql = `UPDATE ${tableName} SET idgroup=NULL
+                    WHERE idgroup=${idgroup} and firewall=${firewall}`;
 
-            var sql = 'UPDATE ' + tableName + ' SET ' +
-                'idgroup = NULL' + ' ' +
-                ' WHERE idgroup = ' + idgroup + " and firewall=" + firewall;
-
-            connection.query(sql, async (error, result) => {
-                if (error) {
-                    logger.error(error);
-                    callback(error, null);
-                } else {
+                connection.query(sql, async (error, result) => {
+                    if (error) return reject(error);
                     if (result.affectedRows > 0) {
                         await modelEventService.emit('update', PolicyRule, {
                             idgroup: idgroup,
                             firewall: firewall
                         });
-                        callback(null, { "result": true });
+                        resolve({ "result": true });
                     } else
-                        callback(null, { "result": false });
-                }
+                        resolve({ "result": false });
+                });
             });
         });
     };

--- a/src/routes/policy/rule.js
+++ b/src/routes/policy/rule.js
@@ -167,55 +167,36 @@ async (req, res) => {
 /* Update Active policy_r  */
 router.put('/active',
 utilsModel.disableFirewallCompileStatus,
-(req, res) => {
+async (req, res) => {
 	//Save data into object
 	var idfirewall = req.body.firewall;
 	var type = req.body.type;
 	var active = req.body.active;
 	var rulesIds = req.body.rulesIds;
-	if (active !== 1)
-		active = 0;
-	db.lockTableCon("policy_r", " WHERE firewall=" + idfirewall + " AND type=" + type, () => {
-		db.startTXcon(() => {
-			for (var rule of rulesIds) {
-				PolicyRule.updatePolicy_r_Active(idfirewall, rule, type, active, (error, data) => {
-					if (error)
-						logger.debug("ERROR UPDATING ACTIVE STATUS for RULE: " + rule + "  Active: " + active);
-					if (data && data.result) {
-						logger.debug("UPDATED ACTIVE STATUS for RULE: " + rule + "  Active: " + active);
-					} else
-						logger.debug("NOT UPDATED ACTIVE STATUS for RULE: " + rule + "  Active: " + active);
-				});
-			}
-			db.endTXcon(() => {});
-		});
+	if (active !== 1) active = 0;
+
+	try {
+		for (var rule of rulesIds) {
+			await PolicyRule.updatePolicy_r_Active(idfirewall, rule, type, active);
+		}
 		res.status(204).end();
-	});
+	} catch(error) { res.status(400).json(error) }
 });
 
 
 /* Update Style policy_r  */
 router.put('/style',
 utilsModel.disableFirewallCompileStatus,
-(req, res) => {
+async (req, res) => {
 	var style = req.body.style;
 	var rulesIds = req.body.rulesIds;
-	db.lockTableCon("policy_r", " WHERE firewall=" + req.body.firewall + " AND type=" + req.body.type, () => {
-		db.startTXcon(() => {
-			for (var rule of rulesIds) {
-				PolicyRule.updatePolicy_r_Style(req.body.firewall, rule, req.body.type, style, (error, data) => {
-					if (error)
-						logger.debug("ERROR UPDATING STYLE for RULE: " + rule + "  STYLE: " + style);
-					if (data && data.result) {
-						logger.debug("UPDATED STYLE for RULE: " + rule + "  STYLE: " + style);
-					} else
-						logger.debug("NOT UPDATED STYLE for RULE: " + rule + "  STYLE: " + style);
-				});
-			}
-			db.endTXcon(() => {});
-		});
-	});
-	res.status(204).end();
+
+	try {
+		for (var rule of rulesIds) {
+			await PolicyRule.updatePolicy_r_Style(req.body.firewall, rule, req.body.type, style);
+		}
+		res.status(204).end();
+	} catch(error) { res.status(400).json(error) }
 });
 
 


### PR DESCRIPTION
Solved this problem originated by a bad transaction management.

query failed: UPDATE `policy_c` SET `status_compiled` = ? WHERE `rule` =
? -- PARAMETERS: [0,18]
error: Error: ER_LOCK_WAIT_TIMEOUT: Lock wait timeout exceeded; try
restarting transaction
    at Query.Sequence._packetToError
(/opt/fwcloud-api/node_modules/mysql/lib/protocol/sequences/Sequence.js:47:14)
    at Query.ErrorPacket
(/opt/fwcloud-api/node_modules/mysql/lib/protocol/sequences/Query.js:77:18)
    at Protocol._parsePacket
(/opt/fwcloud-api/node_modules/mysql/lib/protocol/Protocol.js:291:23)
    at Parser._parsePacket
(/opt/fwcloud-api/node_modules/mysql/lib/protocol/Parser.js:433:10)
    at Parser.write
(/opt/fwcloud-api/node_modules/mysql/lib/protocol/Parser.js:43:10)
    at Protocol.write
(/opt/fwcloud-api/node_modules/mysql/lib/protocol/Protocol.js:38:16)
    at Socket.<anonymous>
(/opt/fwcloud-api/node_modules/mysql/lib/Connection.js:91:28)
    at Socket.<anonymous>
(/opt/fwcloud-api/node_modules/mysql/lib/Connection.js:525:10)
    at Socket.emit (events.js:311:20)
    at addChunk (_stream_readable.js:294:12)
    --------------------
    at Protocol._enqueue
(/opt/fwcloud-api/node_modules/mysql/lib/protocol/Protocol.js:144:48)
    at PoolConnection.query
(/opt/fwcloud-api/node_modules/mysql/lib/Connection.js:201:25)
    at MysqlQueryRunner.<anonymous>
(/opt/fwcloud-api/node_modules/typeorm/driver/mysql/MysqlQueryRunner.js:161:44)
    at step (/opt/fwcloud-api/node_modules/tslib/tslib.js:136:27)
    at Object.next (/opt/fwcloud-api/node_modules/tslib/tslib.js:117:57)
    at fulfilled (/opt/fwcloud-api/node_modules/tslib/tslib.js:107:62)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:97:5) {
  code: 'ER_LOCK_WAIT_TIMEOUT',
  errno: 1205,
  sqlMessage: 'Lock wait timeout exceeded; try restarting transaction',
  sqlState: 'HY000',
  index: 0,
  sql: 'UPDATE `policy_c` SET `status_compiled` = 0 WHERE `rule` = 18'
}
(node:1104) UnhandledPromiseRejectionWarning: QueryFailedError:
ER_LOCK_WAIT_TIMEOUT: Lock wait timeout exceeded; try restarting transaction
    at new QueryFailedError
(/opt/fwcloud-api/node_modules/typeorm/error/QueryFailedError.js:11:28)
    at Query.<anonymous>
(/opt/fwcloud-api/node_modules/typeorm/driver/mysql/MysqlQueryRunner.js:170:45)
    at Query.<anonymous>
(/opt/fwcloud-api/node_modules/mysql/lib/Connection.js:525:10)
    at Query._callback
(/opt/fwcloud-api/node_modules/mysql/lib/Connection.js:491:16)
    at Query.Sequence.end
(/opt/fwcloud-api/node_modules/mysql/lib/protocol/sequences/Sequence.js:83:24)
    at Query.ErrorPacket
(/opt/fwcloud-api/node_modules/mysql/lib/protocol/sequences/Query.js:90:8)
    at Protocol._parsePacket
(/opt/fwcloud-api/node_modules/mysql/lib/protocol/Protocol.js:291:23)
    at Parser._parsePacket
(/opt/fwcloud-api/node_modules/mysql/lib/protocol/Parser.js:433:10)
    at Parser.write
(/opt/fwcloud-api/node_modules/mysql/lib/protocol/Parser.js:43:10)
    at Protocol.write
(/opt/fwcloud-api/node_modules/mysql/lib/protocol/Protocol.js:38:16)
(node:1104) UnhandledPromiseRejectionWarning: Unhandled promise
rejection. This error originated either by throwing inside of an async
function without a catch block, or by rejecting a promise which was not
handled with .catch(). To terminate the node process on unhandled
promise rejection, use the CLI flag `--unhandled-rejections=strict` (see
https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode).
(rejection id: 1)
(node:1104) [DEP0018] DeprecationWarning: Unhandled promise rejections
are deprecated. In the future, promise rejections that are not handled
will terminate the Node.js process with a non-zero exit code.
query failed: UPDATE user SET  confirmation_token =  '' WHERE id = 1
error: Error: ER_LOCK_WAIT_TIMEOUT: Lock wait timeout exceeded; try
restarting transaction
    at Query.Sequence._packetToError
(/opt/fwcloud-api/node_modules/mysql/lib/protocol/sequences/Sequence.js:47:14)
    at Query.ErrorPacket
(/opt/fwcloud-api/node_modules/mysql/lib/protocol/sequences/Query.js:77:18)
    at Protocol._parsePacket
(/opt/fwcloud-api/node_modules/mysql/lib/protocol/Protocol.js:291:23)
    at Parser._parsePacket
(/opt/fwcloud-api/node_modules/mysql/lib/protocol/Parser.js:433:10)
    at Parser.write
(/opt/fwcloud-api/node_modules/mysql/lib/protocol/Parser.js:43:10)
    at Protocol.write
(/opt/fwcloud-api/node_modules/mysql/lib/protocol/Protocol.js:38:16)
    at Socket.<anonymous>
(/opt/fwcloud-api/node_modules/mysql/lib/Connection.js:91:28)
    at Socket.<anonymous>
(/opt/fwcloud-api/node_modules/mysql/lib/Connection.js:525:10)
    at Socket.emit (events.js:311:20)
    at addChunk (_stream_readable.js:294:12)
    --------------------
    at Protocol._enqueue
(/opt/fwcloud-api/node_modules/mysql/lib/protocol/Protocol.js:144:48)
    at PoolConnection.query
(/opt/fwcloud-api/node_modules/mysql/lib/Connection.js:201:25)
    at MysqlQueryRunner.<anonymous>
(/opt/fwcloud-api/node_modules/typeorm/driver/mysql/MysqlQueryRunner.js:161:44)
    at step (/opt/fwcloud-api/node_modules/tslib/tslib.js:136:27)
    at Object.next (/opt/fwcloud-api/node_modules/tslib/tslib.js:117:57)
    at fulfilled (/opt/fwcloud-api/node_modules/tslib/tslib.js:107:62)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:97:5) {
  code: 'ER_LOCK_WAIT_TIMEOUT',
  errno: 1205,
  sqlMessage: 'Lock wait timeout exceeded; try restarting transaction',
  sqlState: 'HY000',
  index: 0,
  sql: "UPDATE user SET  confirmation_token =  '' WHERE id = 1"
}
