### PR TITLE
Bug fixes. Slow api response.

### DIFF
--- a/src/models/policy/PolicyRuleToIPObj.ts
+++ b/src/models/policy/PolicyRuleToIPObj.ts
@@ -729,7 +729,7 @@ export class PolicyRuleToIPObj extends Model {
                                 callback(error, null);
                             } else {
                                 if (result.affectedRows > 0) {
-                                    await modelEventService.emit('delete', PolicyRuleToIPObj, models);
+                                    //await modelEventService.emit('delete', PolicyRuleToIPObj, models);
                                     this.OrderList(999999, rule, position, position_order, ipobj, ipobj_g, _interface);
                                     callback(null, { "result": true, "msg": "deleted" });
                                 } else {

--- a/src/models/policy/PolicyRuleToInterface.ts
+++ b/src/models/policy/PolicyRuleToInterface.ts
@@ -400,7 +400,7 @@ export class PolicyRuleToInterface extends Model {
                                 callback(error, null);
                             } else {
                                 if (result.affectedRows > 0) {
-                                    await modelEventService.emit('delete', PolicyRuleToInterface, models);
+                                    //await modelEventService.emit('delete', PolicyRuleToInterface, models);
                                     this.OrderList(999999, rule, position, old_order, _interface);
                                     callback(null, { "result": true, "msg": "deleted" });
                                 } else {

--- a/src/routes/policy/interface.js
+++ b/src/routes/policy/interface.js
@@ -93,7 +93,7 @@ async(req, res) => {
 			if (data) {
 				if (data.result) {
 					PolicyRule.compilePolicy_r(rule, (error, datac) => {});
-					PolicyRule.compilePolicy_r(new_rule, (error, datac) => {});
+					if (rule != new_rule) PolicyRule.compilePolicy_r(new_rule, (error, datac) => {});
 
 					// If after the move we have empty rule positions, then remove them from the negate position list.
 					try {
@@ -128,7 +128,7 @@ async(req, res) => {
 					PolicyRuleToIPObj.deletePolicy_r__ipobj(rule, -1, -1, interface, position, position_order, async (error, data) => {
 						if (data && data.result) {
 							PolicyRule.compilePolicy_r(rule, (error, datac) => {});
-							PolicyRule.compilePolicy_r(new_rule, (error, datac) => {});
+							if (rule != new_rule) PolicyRule.compilePolicy_r(new_rule, (error, datac) => {});
 
 							// If after the move we have empty rule positions, then remove them from the negate position list.
 							try {

--- a/src/routes/policy/ipobj.js
+++ b/src/routes/policy/ipobj.js
@@ -138,8 +138,10 @@ async (req, res) => {
 			if (data) {
 				if (data.result) {
 					PolicyRule.compilePolicy_r(accessData, (error, datac) => {});
-					accessData.rule = new_rule;
-					PolicyRule.compilePolicy_r(accessData, (error, datac) => {});
+					if (accessData.rule != new_rule) {
+						accessData.rule = new_rule;
+						PolicyRule.compilePolicy_r(accessData, (error, datac) => {});
+					}
 
 					// If after the move we have empty rule positions, then remove them from the negate position list.
 					try {
@@ -176,8 +178,10 @@ async (req, res) => {
 					PolicyRuleToInterface.deletePolicy_r__interface(rule, interface, position, position_order, async (error, data) => {
 						if (data && data.result) {
 							PolicyRule.compilePolicy_r(accessData, (error, datac) => {});
-							accessData.rule = new_rule;
-							PolicyRule.compilePolicy_r(accessData, (error, datac) => {});
+							if (accessData.rule != new_rule) {
+								accessData.rule = new_rule;
+								PolicyRule.compilePolicy_r(accessData, (error, datac) => {});
+							}
 
 							// If after the move we have empty rule positions, then remove them from the negate position list.
 							try {


### PR DESCRIPTION
Solved some bugs for avoid duplicity database errors when generating compilation cache.

Commented a couple of event emiters because at this moment are useless and are the cause of slow api response when moving interface between different rule positions, in the same rule or in different rules.