### PR TITLE
Return lo interface data after firewall/cluster creation.

### DIFF
--- a/src/models/firewall/Cluster.ts
+++ b/src/models/firewall/Cluster.ts
@@ -142,18 +142,14 @@ export class Cluster extends Model {
     }
 
     //Add new cluster
-    public static async insertCluster(clusterData, callback) {
-        db.get((error, connection) => {
-            if (error)
-                callback(error, null);
-            logger().debug(clusterData);
-            connection.query('INSERT INTO ' + tableName + ' SET ?', clusterData, (error, result) => {
-                if (error) {
-                    callback(error, null);
-                } else {
-                    //devolvemos la última id insertada
-                    callback(null, { "insertId": result.insertId });
-                }
+    public static async insertCluster(clusterData) {
+		return new Promise((resolve, reject) => {
+            db.get((error, connection) => {
+                if (error) return reject(error);
+                connection.query(`INSERT INTO ${tableName} SET ?`, clusterData, (error, result) => {
+                    if (error) return reject(error);
+                    resolve(result.insertId);
+                });
             });
         });
     }

--- a/src/models/fwcloud/FwCloud.ts
+++ b/src/models/fwcloud/FwCloud.ts
@@ -110,12 +110,16 @@ export class FwCloud extends Model {
     public removeDataDirectories() {
         FSHelper.rmDirectorySync(this.getPkiDirectoryPath());
         FSHelper.rmDirectorySync(this.getPolicyDirectoryPath());
+        FSHelper.rmDirectorySync(this.getSnapshotDirectoryPath());
     }
 
     @AfterInsert()
     async createDataDirectories() {
+        // Make sure that doesn't exists any data directory of the just created FWCloud.
+        this.removeDataDirectories();
         fs.mkdirpSync(this.getPkiDirectoryPath());
         fs.mkdirpSync(this.getPolicyDirectoryPath());
+        fs.mkdirpSync(this.getSnapshotDirectoryPath());
     }
 
     /**

--- a/src/models/interface/Interface.ts
+++ b/src/models/interface/Interface.ts
@@ -498,15 +498,15 @@ export class Interface extends Model {
 						options: null,
 						comment: 'IPv4 loopback interface address.'
 					};
-					await IPObj.insertIpobj(connection, ipobjData);
+					const ipv4Id = await IPObj.insertIpobj(connection, ipobjData);
 
 					ipobjData.address = '::1';
 					ipobjData.netmask = '/128';
 					ipobjData.ip_version = 6;
 					ipobjData.comment = 'IPv6 loopback interface address.';
-					await IPObj.insertIpobj(connection, ipobjData);
+					const ipv6Id = await IPObj.insertIpobj(connection, ipobjData);
 
-					resolve(interfaceId);
+					resolve({ "ifId": interfaceId, "ipv4Id": ipv4Id, "ipv6Id": ipv6Id });
 				});
 			});
 		});

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -183,6 +183,7 @@ utilsModel.removeFwcloudDataDir = fwcloud => {
 		try {
 			await utilsModel.deleteFolder(config.get('policy').data_dir+'/'+fwcloud);
 			await utilsModel.deleteFolder(config.get('pki').data_dir+'/'+fwcloud);
+			await utilsModel.deleteFolder(config.get('snapshot').data_dir+'/'+fwcloud);
 			resolve();
 		} catch(error) { reject(error) }
   });


### PR DESCRIPTION
Useful for the interfaces autodiscover procedure when the user selects the lo interface/ip as install interface/ip.

Moreover, add code for remove the fwcloud snapshots directory when we remove a fwcloud, and for clean fwcloud directories when we create a new fwcloud.