### PR TITLE
Remove ValidationError _object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [] -
+### Fixed
+- Remove `_object` property from ValidationError response.
+
 ## [1.3.1] - 2021-10-08
 ### Added
 - Allow the use of vtun interfaces in OpenVPN configurations. 

--- a/src/middleware/InputValidation.ts
+++ b/src/middleware/InputValidation.ts
@@ -73,6 +73,10 @@ export class InputValidation extends Middleware {
             // If we arrive here then input data has been sucessfully validated.  
             next();
         } catch (error) {
+            if (Object.prototype.hasOwnProperty.call(error, "_object")) {
+                delete error._object;
+            }
+
             logger().error('Error during input validation check: ' + JSON.stringify(error));
             
             if (error.code === "MODULE_NOT_FOUND") {

--- a/tests/e2e/middlewares/input-validation.middleware.e2e.spec.ts
+++ b/tests/e2e/middlewares/input-validation.middleware.e2e.spec.ts
@@ -1,0 +1,58 @@
+/*!
+    Copyright 2019 SOLTECSIS SOLUCIONES TECNOLOGICAS, SLU
+    https://soltecsis.com
+    info@soltecsis.com
+
+
+    This file is part of FWCloud (https://fwcloud.net).
+
+    FWCloud is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    FWCloud is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with FWCloud.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { describeName, expect, testSuite } from "../../mocha/global-setup";
+import { Application } from "../../../src/Application";
+import request = require("supertest");
+import { FwCloudFactory, FwCloudProduct } from "../../utils/fwcloud-factory";
+import { attachSession, createUser, generateSession } from "../../utils/utils";
+import { User } from "../../../src/models/user/User";
+
+describe(describeName('InputValidation Middleware E2E test'), () => {
+    let app: Application;
+    let fwcProduct: FwCloudProduct;
+    let adminUser: User;
+    let session: string;
+
+    beforeEach(async () => {
+        await testSuite.resetDatabaseData();
+        app = testSuite.app;
+        fwcProduct = await new FwCloudFactory().make();
+        adminUser = await createUser({role: 1});
+        session = generateSession(adminUser);
+    });
+
+    it('should remove _object from the validation error', async() => {
+        app.config.set('confirmation_token', false);
+
+        await request(app.express)
+            .post("/firewall")
+            .set('Cookie', [attachSession(session)])
+            .send({
+                fwcloud: fwcProduct.fwcloud.id
+            })
+            .expect(400)
+            .expect((response) => {
+                expect(response.body._object).to.be.undefined;
+            });
+    });
+})


### PR DESCRIPTION
This PR removes `_object` property from `ValidationError` thrown by Joi validation before being included as a response.

Fixes #515