### PR TITLE
improve keys:generate command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - Bug in restrictions check when removing node from a firewall cluster.
-
+- Prevent `keys:generate` cli command from generating new keys if they are already defined (included `--force` option)
 
 ## [1.4.0] - 2021-12-02
 ### Added

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -49,6 +49,12 @@ export class Output
         this.writeLine(margin);
     }
 
+    public warn(message: string, margin: number = 1): void {
+        this.writeLine(margin);
+        this.writeln(chalk.bgYellow.bold.black(`${Output.symbols().warning} ${message}`));
+        this.writeLine(margin);
+    }
+
     public error(message: string): void {
         this.writeln(chalk.bgRed.bold.white(`${Output.symbols().error} ${message}`));
     }

--- a/tests/Unit/cli/commands/keys-generate.command.spec.ts
+++ b/tests/Unit/cli/commands/keys-generate.command.spec.ts
@@ -111,7 +111,7 @@ describe(describeName('KeysGenerateCommand tests'), () => {
         stubVar.restore();
     });
 
-    it('should overwrite SESSION_SECRET if is defined', async () => {
+    it('should not overwrite SESSION_SECRET if is defined', async () => {
         const stubVar = sinon.stub(KeysGenerateCommand, <any> 'ENV_FILENAME').value(testEnvPath);
         let envData: string = fse.readFileSync(testEnvPath).toString()
         envData = envData.replace(new RegExp('^SESSION_SECRET=(.)*\n', 'm'), `SESSION_SECRET=test\n`);
@@ -120,6 +120,25 @@ describe(describeName('KeysGenerateCommand tests'), () => {
         await runCLICommandIsolated(testSuite, async () => {
             return new KeysGenerateCommand().safeHandle({
             $0: "key:generate",
+            _: []
+        })});
+
+        const envContent: string = readTestEnvContent();
+
+        expect(envContent).matches(new RegExp('SESSION_SECRET=test'));
+        stubVar.restore()
+    });
+
+    it('should overwrite SESSION_SECRET if force option is defined', async () => {
+        const stubVar = sinon.stub(KeysGenerateCommand, <any> 'ENV_FILENAME').value(testEnvPath);
+        let envData: string = fse.readFileSync(testEnvPath).toString()
+        envData = envData.replace(new RegExp('^SESSION_SECRET=(.)*\n', 'm'), `SESSION_SECRET=test\n`);
+        fse.writeFileSync(testEnvPath, envData);
+
+        await runCLICommandIsolated(testSuite, async () => {
+            return new KeysGenerateCommand().safeHandle({
+            $0: "key:generate",
+            force: true,
             _: []
         })});
 

--- a/tests/Unit/cli/commands/keys-generate.command.spec.ts
+++ b/tests/Unit/cli/commands/keys-generate.command.spec.ts
@@ -148,7 +148,7 @@ describe(describeName('KeysGenerateCommand tests'), () => {
         stubVar.restore()
     });
 
-    it('should overwrite CRYPT_SECRET if is defined', async () => {
+    it('should not overwrite CRYPT_SECRET if is defined', async () => {
         const stubVar = sinon.stub(KeysGenerateCommand, <any> 'ENV_FILENAME').value(testEnvPath);
         let envData: string = fse.readFileSync(testEnvPath).toString()
         envData = envData.replace(new RegExp('^CRYPT_SECRET=(.)*\n', 'm'), `CRYPT_SECRET=test\n`);
@@ -157,6 +157,25 @@ describe(describeName('KeysGenerateCommand tests'), () => {
         await runCLICommandIsolated(testSuite, async () => {
             return new KeysGenerateCommand().safeHandle({
             $0: "keys:generate",
+            _: []
+        })});
+
+        const envContent: string = readTestEnvContent();
+
+        expect(envContent).matches(new RegExp('CRYPT_SECRET=test'));
+        stubVar.restore()
+    });
+
+    it('should overwrite CRYPT_SECRET if force option is defined', async () => {
+        const stubVar = sinon.stub(KeysGenerateCommand, <any> 'ENV_FILENAME').value(testEnvPath);
+        let envData: string = fse.readFileSync(testEnvPath).toString()
+        envData = envData.replace(new RegExp('^CRYPT_SECRET=(.)*\n', 'm'), `CRYPT_SECRET=test\n`);
+        fse.writeFileSync(testEnvPath, envData);
+
+        await runCLICommandIsolated(testSuite, async () => {
+            return new KeysGenerateCommand().safeHandle({
+            $0: "keys:generate",
+            force: true,
             _: []
         })});
 


### PR DESCRIPTION
This PR improves `keys:generate` command in order to avoid generating new keys once they have been already defined. It also includes the `--force` option in case we want to generate them anyway.

These changes are required in order to dockerize `fwcloud-api` as we need a way to avoid regenerating keys once they are defined.