### PR TITLE
UPDATE: Modify unique constraints in WireGuard migration to include '…

### DIFF
--- a/src/database/migrations/1.0.0/1737018559931-WireGuard.ts
+++ b/src/database/migrations/1.0.0/1737018559931-WireGuard.ts
@@ -128,7 +128,7 @@ export class WireGuard1737018559931 implements MigrationInterface {
             default: null,
           },
         ],
-        uniques: [{ columnNames: ['firewall', 'crt'] }],
+        uniques: [{ columnNames: ['firewall', 'wireguard', 'crt'] }],
         foreignKeys: [
           {
             columnNames: ['crt'],


### PR DESCRIPTION
…wireguard' column