### PR TITLE
Add unit and E2E tests for routing and VPN functionalities

### DIFF
--- a/tests/Unit/compiler/routing/route.spec.ts
+++ b/tests/Unit/compiler/routing/route.spec.ts
@@ -444,5 +444,43 @@ describe('Routing route compiler', async () => {
       expect(compilation[0].id).to.equal(ids[0]);
       expect(compilation[1].id).to.equal(ids[1]);
     });
+
+    it('should throw if compiling an invalid or corrupt route', () => {
+      const invalidRoute: any = { id: null, ipobjs: null };
+      let errorCaught = false;
+      try {
+        compiler.compile('Route', [invalidRoute]);
+      } catch (err) {
+        errorCaught = true;
+      }
+      expect(errorCaught).to.be.true;
+    });
+
+    it('should throw if compiling a route with no objects', () => {
+      const emptyRoute: any = {
+        id: 99999,
+        ipobjs: [],
+      };
+      let errorCaught = false;
+      try {
+        compiler.compile('Route', [emptyRoute]);
+      } catch (err) {
+        errorCaught = true;
+      }
+      expect(errorCaught).to.be.true;
+    });
+
+    it('should return empty compilation for non-existent route IDs', async () => {
+      const ids = [999999, 888888]; // IDs that do not exist
+      const routes = await routingTableService.getRoutingTableData<RouteItemForCompiler>(
+        'compiler',
+        fwc.fwcloud.id,
+        fwc.firewall.id,
+        fwc.routingTable.id,
+        ids,
+      );
+      const compilation = compiler.compile('Route', routes);
+      expect(compilation).to.be.an('array').with.length(0);
+    });
   });
 });

--- a/tests/Unit/compiler/routing/routing-rule.spec.ts
+++ b/tests/Unit/compiler/routing/routing-rule.spec.ts
@@ -433,5 +433,43 @@ describe('Routing rule compiler', () => {
       expect(compilation[0].id).to.equal(ids[0]);
       expect(compilation[1].id).to.equal(ids[1]);
     });
+
+    it('should handle invalid rule data gracefully', async () => {
+      const invalidRule: any = { id: null, ipobjs: null, mark: null };
+      let errorCaught = false;
+      try {
+        compiler.compile('Rule', [invalidRule]);
+      } catch (err) {
+        errorCaught = true;
+      }
+      expect(errorCaught).to.be.true;
+    });
+
+    it('should throw if compiling a rule with no objects', async () => {
+      const emptyRule: any = {
+        id: 99999,
+        ipobjs: [],
+        mark: null,
+      };
+      let errorCaught = false;
+      try {
+        compiler.compile('Rule', [emptyRule]);
+      } catch (err) {
+        errorCaught = true;
+      }
+      expect(errorCaught).to.be.true;
+    });
+
+    it('should return empty compilation for non-existent rule IDs', async () => {
+      const ids = [999999, 888888]; // IDs that do not exist
+      const rules = await routingRuleService.getRoutingRulesData<RoutingRuleItemForCompiler>(
+        'compiler',
+        fwc.fwcloud.id,
+        fwc.firewall.id,
+        ids,
+      );
+      const compilation = compiler.compile('Rule', rules);
+      expect(compilation).to.be.an('array').with.length(0);
+    });
   });
 });

--- a/tests/Unit/routing/routing-rule/getRoutingRulesData.spec.ts
+++ b/tests/Unit/routing/routing-rule/getRoutingRulesData.spec.ts
@@ -116,11 +116,15 @@ describe('Routing rules data fetch for compiler or grid', () => {
         expect(items).to.deep.include(item);
       });
 
-      it('should include OpenVPN Prefix data', () => {
+      it('should include IPSec data', () => {
         item.type = 5;
-        item.address = fwc.ipobjs.get('openvpn-cli1-addr').address;
+        item.address = fwc.ipobjs.get('ipsec-cli3-addr').address;
         expect(items).to.deep.include(item);
-        item.address = fwc.ipobjs.get('openvpn-cli2-addr').address;
+      });
+
+      it('should include WireGuard data', () => {
+        item.type = 5;
+        item.address = fwc.ipobjs.get('wireguard-cli3-addr').address;
         expect(items).to.deep.include(item);
       });
 
@@ -181,11 +185,15 @@ describe('Routing rules data fetch for compiler or grid', () => {
         expect(items).to.deep.include(item);
       });
 
-      it('should include OpenVPN Prefix data', () => {
+      it('should include IPSec data', () => {
         item.type = 5;
-        item.address = fwc.ipobjs.get('openvpn-cli1-addr').address;
+        item.address = fwc.ipobjs.get('ipsec-cli3-addr').address;
         expect(items).to.deep.include(item);
-        item.address = fwc.ipobjs.get('openvpn-cli2-addr').address;
+      });
+
+      it('should include WireGuard data', () => {
+        item.type = 5;
+        item.address = fwc.ipobjs.get('wireguard-cli3-addr').address;
         expect(items).to.deep.include(item);
       });
     });

--- a/tests/Unit/routing/table/getRoutingTableData.spec.ts
+++ b/tests/Unit/routing/table/getRoutingTableData.spec.ts
@@ -35,6 +35,10 @@ import { expect, testSuite } from '../../../mocha/global-setup';
 import { FwCloudFactory, FwCloudProduct } from '../../../utils/fwcloud-factory';
 import { EntityManager } from 'typeorm';
 import db from '../../../../src/database/database-manager';
+import { RouteToIPSec } from '../../../../src/models/routing/route/route-to-ipsec.model';
+import { RouteToWireGuard } from '../../../../src/models/routing/route/route-to-wireguard.model';
+import { RouteToIPSecPrefix } from '../../../../src/models/routing/route/route-to-ipsec-prefix.model';
+import { RouteToWireGuardPrefix } from '../../../../src/models/routing/route/route-to-wireguard-prefix.model';
 
 describe('Routing table data fetch for compiler or grid', () => {
   let routeService: RouteService;
@@ -118,6 +122,18 @@ describe('Routing table data fetch for compiler or grid', () => {
         expect(items).to.deep.include(item);
       });
 
+      it('should include IPSec data', () => {
+        item.type = 5;
+        item.address = fwc.ipobjs.get('ipsec-cli3-addr').address;
+        expect(items).to.deep.include(item);
+      });
+
+      it('should include WireGuard data', () => {
+        item.type = 5;
+        item.address = fwc.ipobjs.get('wireguard-cli3-addr').address;
+        expect(items).to.deep.include(item);
+      });
+
       it('should include OpenVPN Prefix data', () => {
         item.type = 5;
         item.address = fwc.ipobjs.get('openvpn-cli1-addr').address;
@@ -173,6 +189,18 @@ describe('Routing table data fetch for compiler or grid', () => {
       it('should include OpenVPN data', () => {
         item.type = 5;
         item.address = fwc.ipobjs.get('openvpn-cli3-addr').address;
+        expect(items).to.deep.include(item);
+      });
+
+      it('should include IPSec data', () => {
+        item.type = 5;
+        item.address = fwc.ipobjs.get('ipsec-cli3-addr').address;
+        expect(items).to.deep.include(item);
+      });
+
+      it('should include WireGuard data', () => {
+        item.type = 5;
+        item.address = fwc.ipobjs.get('wireguard-cli3-addr').address;
         expect(items).to.deep.include(item);
       });
 
@@ -298,6 +326,40 @@ describe('Routing table data fetch for compiler or grid', () => {
         expect(items).to.deep.include(item);
       });
 
+      it('should include IPSec data', async () => {
+        item.id = fwc.ipsecClients.get('IPSec-Cli-3').id;
+        item.type = 331;
+        item.name = fwc.crts.get('IPSec-Cli-3').cn;
+        item.firewall_id = fwc.firewall.id;
+        item.firewall_name = fwc.firewall.name;
+        item._order = (
+          await manager.getRepository(RouteToIPSec).findOneOrFail({
+            where: {
+              routeId: fwc.routes.get('route1').id,
+              ipSecId: item.id,
+            },
+          })
+        ).order;
+        expect(items).to.deep.include(item);
+      });
+
+      it('should include WireGuard data', async () => {
+        item.id = fwc.wireguardClients.get('WireGuard-Cli-3').id;
+        item.type = 321;
+        item.name = fwc.crts.get('WireGuard-Cli-3').cn;
+        item.firewall_id = fwc.firewall.id;
+        item.firewall_name = fwc.firewall.name;
+        item._order = (
+          await manager.getRepository(RouteToWireGuard).findOneOrFail({
+            where: {
+              routeId: fwc.routes.get('route1').id,
+              wireGuardId: item.id,
+            },
+          })
+        ).order;
+        expect(items).to.deep.include(item);
+      });
+
       it('should include OpenVPN Prefix data', async () => {
         item.id = fwc.openvpnPrefix.id;
         item.type = 401;
@@ -314,8 +376,41 @@ describe('Routing table data fetch for compiler or grid', () => {
         ).order;
         expect(items).to.deep.include(item);
       });
-    });
 
+      it('should include IPSec Prefix data', async () => {
+        item.id = fwc.ipsecPrefix.id;
+        item.type = 403;
+        item.name = fwc.ipsecPrefix.name;
+        item.firewall_id = fwc.firewall.id;
+        item.firewall_name = fwc.firewall.name;
+        item._order = (
+          await manager.getRepository(RouteToIPSecPrefix).findOneOrFail({
+            where: {
+              routeId: fwc.routes.get('route1').id,
+              ipsecPrefixId: item.id,
+            },
+          })
+        ).order;
+        expect(items).to.deep.include(item);
+      });
+
+      it('should include WireGuard Prefix data', async () => {
+        item.id = fwc.wireguardPrefix.id;
+        item.type = 402;
+        item.name = fwc.wireguardPrefix.name;
+        item.firewall_id = fwc.firewall.id;
+        item.firewall_name = fwc.firewall.name;
+        item._order = (
+          await manager.getRepository(RouteToWireGuardPrefix).findOneOrFail({
+            where: {
+              routeId: fwc.routes.get('route1').id,
+              wireGuardPrefixId: item.id,
+            },
+          })
+        ).order;
+        expect(items).to.deep.include(item);
+      });
+    });
     describe('Into group', () => {
       beforeEach(() => {
         items = routes[1].items; // This route has the group of objects.

--- a/tests/e2e/api/routing/route/route.e2e.spec.ts
+++ b/tests/e2e/api/routing/route/route.e2e.spec.ts
@@ -887,7 +887,6 @@ describe(describeName('Route E2E Tests'), () => {
       });
 
       it('admin user should create a route with IPSec', async () => {
-        // Suponiendo que existe un cliente IPSec válido
         const ipsecIds: { id: number; order: number }[] = Array.from(
           fwcProduct.ipsecClients.values(),
         ).map((c, index) => ({ id: c.id, order: index + 1 }));
@@ -911,7 +910,6 @@ describe(describeName('Route E2E Tests'), () => {
       });
 
       it('admin user should create a route with WireGuard', async () => {
-        // Suponiendo que existe un cliente WireGuard válido
         const wireguardIds: { id: number; order: number }[] = Array.from(
           fwcProduct.wireguardClients.values(),
         ).map((c, index) => ({ id: c.id, order: index + 1 }));

--- a/tests/e2e/api/routing/route/route.e2e.spec.ts
+++ b/tests/e2e/api/routing/route/route.e2e.spec.ts
@@ -51,6 +51,7 @@ import { RouteMoveToGatewayDto } from '../../../../../src/controllers/routing/ro
 import db from '../../../../../src/database/database-manager';
 import { IPSec } from '../../../../../src/models/vpn/ipsec/IPSec';
 import { WireGuard } from '../../../../../src/models/vpn/wireguard/WireGuard';
+import { comment } from '../../../../../src/middleware/joi_schemas/shared';
 
 describe(describeName('Route E2E Tests'), () => {
   let app: Application;
@@ -861,6 +862,140 @@ describe(describeName('Route E2E Tests'), () => {
             expect(response.body.data.routingTableId).to.eq(table.id);
           });
       });
+
+      it('admin user should create a route with OpenVPN', async () => {
+        const openVPNIds: { id: number; order: number }[] = Array.from(
+          fwcProduct.openvpnClients.values(),
+        ).map((c, index) => ({ id: c.id, order: index + 1 }));
+        return await request(app.express)
+          .post(
+            _URL().getURL('fwclouds.firewalls.routing.tables.routes.store', {
+              fwcloud: fwCloud.id,
+              firewall: firewall.id,
+              routingTable: table.id,
+            }),
+          )
+          .send({
+            gatewayId: gateway.id,
+            openVPNIds: openVPNIds,
+          })
+          .set('Cookie', [attachSession(adminUserSessionId)])
+          .expect(201)
+          .then((response) => {
+            expect(response.body.data.routingTableId).to.eq(table.id);
+          });
+      });
+
+      it('admin user should create a route with IPSec', async () => {
+        // Suponiendo que existe un cliente IPSec válido
+        const ipsecIds: { id: number; order: number }[] = Array.from(
+          fwcProduct.ipsecClients.values(),
+        ).map((c, index) => ({ id: c.id, order: index + 1 }));
+        return await request(app.express)
+          .post(
+            _URL().getURL('fwclouds.firewalls.routing.tables.routes.store', {
+              fwcloud: fwCloud.id,
+              firewall: firewall.id,
+              routingTable: table.id,
+            }),
+          )
+          .send({
+            gatewayId: gateway.id,
+            ipsecIds: ipsecIds,
+          })
+          .set('Cookie', [attachSession(adminUserSessionId)])
+          .expect(201)
+          .then((response) => {
+            expect(response.body.data.routingTableId).to.eq(table.id);
+          });
+      });
+
+      it('admin user should create a route with WireGuard', async () => {
+        // Suponiendo que existe un cliente WireGuard válido
+        const wireguardIds: { id: number; order: number }[] = Array.from(
+          fwcProduct.wireguardClients.values(),
+        ).map((c, index) => ({ id: c.id, order: index + 1 }));
+        return await request(app.express)
+          .post(
+            _URL().getURL('fwclouds.firewalls.routing.tables.routes.store', {
+              fwcloud: fwCloud.id,
+              firewall: firewall.id,
+              routingTable: table.id,
+            }),
+          )
+          .send({
+            gatewayId: gateway.id,
+            wireguardIds: wireguardIds,
+          })
+          .set('Cookie', [attachSession(adminUserSessionId)])
+          .expect(201)
+          .then((response) => {
+            expect(response.body.data.routingTableId).to.eq(table.id);
+          });
+      });
+
+      it('admin user should create a route with OpenVPN prefix', async () => {
+        const openvpnPrefixId = fwcProduct.openvpnPrefix.id;
+        return await request(app.express)
+          .post(
+            _URL().getURL('fwclouds.firewalls.routing.tables.routes.store', {
+              fwcloud: fwCloud.id,
+              firewall: firewall.id,
+              routingTable: table.id,
+            }),
+          )
+          .send({
+            gatewayId: gateway.id,
+            openVPNPrefixIds: [{ id: openvpnPrefixId, order: 1 }],
+          })
+          .set('Cookie', [attachSession(adminUserSessionId)])
+          .expect(201)
+          .then((response) => {
+            expect(response.body.data.routingTableId).to.eq(table.id);
+          });
+      });
+
+      it('admin user should create a route with IPSec prefix', async () => {
+        const ipsecPrefixId = fwcProduct.ipsecPrefix.id;
+        return await request(app.express)
+          .post(
+            _URL().getURL('fwclouds.firewalls.routing.tables.routes.store', {
+              fwcloud: fwCloud.id,
+              firewall: firewall.id,
+              routingTable: table.id,
+            }),
+          )
+          .send({
+            gatewayId: gateway.id,
+            ipsecPrefixIds: [{ id: ipsecPrefixId, order: 1 }],
+          })
+          .set('Cookie', [attachSession(adminUserSessionId)])
+          .expect(201)
+          .then((response) => {
+            expect(response.body.data.routingTableId).to.eq(table.id);
+          });
+      });
+
+      it('admin user should create a route with WireGuard prefix', async () => {
+        const wireguardPrefixId = fwcProduct.wireguardPrefix.id;
+        return await request(app.express)
+          .post(
+            _URL().getURL('fwclouds.firewalls.routing.tables.routes.store', {
+              fwcloud: fwCloud.id,
+              firewall: firewall.id,
+              routingTable: table.id,
+            }),
+          )
+          .send({
+            gatewayId: gateway.id,
+            wireguardPrefixIds: [{ id: wireguardPrefixId, order: 1 }],
+          })
+          .set('Cookie', [attachSession(adminUserSessionId)])
+          .expect(201)
+          .then((response) => {
+            expect(response.body.data.routingTableId).to.eq(table.id);
+          });
+      });
     });
 
     describe('@copy', () => {
@@ -1035,7 +1170,7 @@ describe(describeName('Route E2E Tests'), () => {
           .expect(401);
       });
 
-      it('regular user which does not belong to the fwcloud should not create a route', async () => {
+      it('regular user which does not belong to the fwcloud should not update a route', async () => {
         return await request(app.express)
           .put(
             _URL().getURL('fwclouds.firewalls.routing.tables.routes.update', {
@@ -1077,7 +1212,7 @@ describe(describeName('Route E2E Tests'), () => {
           });
       });
 
-      it('admin user should create a route', async () => {
+      it('admin user should update a route', async () => {
         return await request(app.express)
           .put(
             _URL().getURL('fwclouds.firewalls.routing.tables.routes.update', {
@@ -1089,6 +1224,150 @@ describe(describeName('Route E2E Tests'), () => {
           )
           .send({
             gatewayId: gateway.id,
+            comment: 'other_route',
+          })
+          .set('Cookie', [attachSession(adminUserSessionId)])
+          .expect(200)
+          .then((response) => {
+            expect(response.body.data.comment).to.eq('other_route');
+          });
+      });
+
+      it('admin user should update a route with OpenVPN client', async () => {
+        const openVPNIds: { id: number; order: number }[] = Array.from(
+          fwcProduct.openvpnClients.values(),
+        ).map((c, index) => ({ id: c.id, order: index + 1 }));
+        return await request(app.express)
+          .put(
+            _URL().getURL('fwclouds.firewalls.routing.tables.routes.update', {
+              fwcloud: fwCloud.id,
+              firewall: firewall.id,
+              routingTable: table.id,
+              route: route.id,
+            }),
+          )
+          .send({
+            gatewayId: gateway.id,
+            openVPNIds: openVPNIds,
+            comment: 'other_route',
+          })
+          .set('Cookie', [attachSession(adminUserSessionId)])
+          .expect(200)
+          .then((response) => {
+            expect(response.body.data.comment).to.eq('other_route');
+          });
+      });
+
+      it('admin user should update a route with IPSec client', async () => {
+        const ipsecIds: { id: number; order: number }[] = Array.from(
+          fwcProduct.ipsecClients.values(),
+        ).map((c, index) => ({ id: c.id, order: index + 1 }));
+        return await request(app.express)
+          .put(
+            _URL().getURL('fwclouds.firewalls.routing.tables.routes.update', {
+              fwcloud: fwCloud.id,
+              firewall: firewall.id,
+              routingTable: table.id,
+              route: route.id,
+            }),
+          )
+          .send({
+            gatewayId: gateway.id,
+            ipsecIds: ipsecIds,
+            comment: 'other_route',
+          })
+          .set('Cookie', [attachSession(adminUserSessionId)])
+          .expect(200)
+          .then((response) => {
+            expect(response.body.data.comment).to.eq('other_route');
+          });
+      });
+
+      it('admin user should update a route with WireGuard client', async () => {
+        const wireguardIds: { id: number; order: number }[] = Array.from(
+          fwcProduct.wireguardClients.values(),
+        ).map((c, index) => ({ id: c.id, order: index + 1 }));
+        return await request(app.express)
+          .put(
+            _URL().getURL('fwclouds.firewalls.routing.tables.routes.update', {
+              fwcloud: fwCloud.id,
+              firewall: firewall.id,
+              routingTable: table.id,
+              route: route.id,
+            }),
+          )
+          .send({
+            gatewayId: gateway.id,
+            wireguardIds: wireguardIds,
+            comment: 'other_route',
+          })
+          .set('Cookie', [attachSession(adminUserSessionId)])
+          .expect(200)
+          .then((response) => {
+            expect(response.body.data.comment).to.eq('other_route');
+          });
+      });
+
+      it('admin user should update a route with OpenVPN prefix', async () => {
+        const openvpnPrefixId = fwcProduct.openvpnPrefix.id;
+        return await request(app.express)
+          .put(
+            _URL().getURL('fwclouds.firewalls.routing.tables.routes.update', {
+              fwcloud: fwCloud.id,
+              firewall: firewall.id,
+              routingTable: table.id,
+              route: route.id,
+            }),
+          )
+          .send({
+            gatewayId: gateway.id,
+            openVPNPrefixIds: [{ id: openvpnPrefixId, order: 1 }],
+            comment: 'other_route',
+          })
+          .set('Cookie', [attachSession(adminUserSessionId)])
+          .expect(200)
+          .then((response) => {
+            expect(response.body.data.comment).to.eq('other_route');
+          });
+      });
+
+      it('admin user should update a route with IPSec prefix', async () => {
+        const ipsecPrefixId = fwcProduct.ipsecPrefix.id;
+        return await request(app.express)
+          .put(
+            _URL().getURL('fwclouds.firewalls.routing.tables.routes.update', {
+              fwcloud: fwCloud.id,
+              firewall: firewall.id,
+              routingTable: table.id,
+              route: route.id,
+            }),
+          )
+          .send({
+            gatewayId: gateway.id,
+            ipsecPrefixIds: [{ id: ipsecPrefixId, order: 1 }],
+            comment: 'other_route',
+          })
+          .set('Cookie', [attachSession(adminUserSessionId)])
+          .expect(200)
+          .then((response) => {
+            expect(response.body.data.comment).to.eq('other_route');
+          });
+      });
+
+      it('admin user should update a route with WireGuard prefix', async () => {
+        const wireguardPrefixId = fwcProduct.wireguardPrefix.id;
+        return await request(app.express)
+          .put(
+            _URL().getURL('fwclouds.firewalls.routing.tables.routes.update', {
+              fwcloud: fwCloud.id,
+              firewall: firewall.id,
+              routingTable: table.id,
+              route: route.id,
+            }),
+          )
+          .send({
+            gatewayId: gateway.id,
+            wireguardPrefixIds: [{ id: wireguardPrefixId, order: 1 }],
             comment: 'other_route',
           })
           .set('Cookie', [attachSession(adminUserSessionId)])


### PR DESCRIPTION
- Implement tests for invalid and non-existent routes in route compiler.
- Add tests for handling invalid routing rules and non-existent rule IDs.
- Enhance WireGuard prefix model tests to ensure correct prefix node creation.
- Update routing rule data fetch tests to include IPSec and WireGuard data.
- Extend E2E tests for creating and updating routes with OpenVPN, IPSec, and WireGuard clients and prefixes.
- Ensure order preservation during move and copy operations in routing rules.