### PR TITLE
ADD: enforce explicit audit expectations for mutating controller routes

### DIFF
--- a/tests/Unit/fonaments/http/router/audit-expectations.ts
+++ b/tests/Unit/fonaments/http/router/audit-expectations.ts
@@ -1,0 +1,300 @@
+/*
+    Copyright 2026 SOLTECSIS SOLUCIONES TECNOLOGICAS, SLU
+    https://soltecsis.com
+    info@soltecsis.com
+
+
+    This file is part of FWCloud (https://fwcloud.net).
+
+    FWCloud is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    FWCloud is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with FWCloud.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+export type AuditRouteExpectation = {
+  audited: boolean;
+  notes?: string;
+};
+
+export type AuditRouteExpectationManifest = Readonly<Record<string, AuditRouteExpectation>>;
+
+// These routes are excluded from the manifest check because they are internal health probes.
+export const INTERNAL_MUTATING_ROUTE_EXCEPTIONS = new Set<string>(['PUT /ping']);
+
+// Single source of truth for mutating controller route audit expectations.
+// Key format: '<METHOD> <normalized-path>'.
+// When adding a mutating controller route, add or update the corresponding key here.
+export const auditRouteExpectationManifest: AuditRouteExpectationManifest = {
+  'DELETE /aiassistant': { audited: true },
+  'DELETE /backups/:backup': { audited: true },
+  'DELETE /fwclouds/:fwcloud/firewalls/:firewall/routeGroups/:routeGroup': { audited: true },
+  'DELETE /fwclouds/:fwcloud/firewalls/:firewall/routingGroups/:routingGroup': { audited: true },
+  'DELETE /fwclouds/:fwcloud/firewalls/:firewall/routingRules/:routingRule': { audited: true },
+  'DELETE /fwclouds/:fwcloud/firewalls/:firewall/routingRules/bulkRemove': { audited: true },
+  'DELETE /fwclouds/:fwcloud/firewalls/:firewall/routingTables/:routingTable': { audited: true },
+  'DELETE /fwclouds/:fwcloud/firewalls/:firewall/routingTables/:routingTable/routes/:route': {
+    audited: true,
+  },
+  'DELETE /fwclouds/:fwcloud/firewalls/:firewall/routingTables/:routingTable/routes/bulkRemove': {
+    audited: true,
+  },
+  'DELETE /fwclouds/:fwcloud/firewalls/:firewall/system/dhcpGroups/:dhcpgroup': { audited: true },
+  'DELETE /fwclouds/:fwcloud/firewalls/:firewall/system/dhcpRules/:dhcp': { audited: true },
+  'DELETE /fwclouds/:fwcloud/firewalls/:firewall/system/dhcpRules/bulkRemove': { audited: true },
+  'DELETE /fwclouds/:fwcloud/firewalls/:firewall/system/haproxyGroups/:haproxygroup': {
+    audited: true,
+  },
+  'DELETE /fwclouds/:fwcloud/firewalls/:firewall/system/haproxyRules/:haproxy': { audited: true },
+  'DELETE /fwclouds/:fwcloud/firewalls/:firewall/system/haproxyRules/bulkRemove': { audited: true },
+  'DELETE /fwclouds/:fwcloud/firewalls/:firewall/system/keepalivedGroups/:keepalivedgroup': {
+    audited: true,
+  },
+  'DELETE /fwclouds/:fwcloud/firewalls/:firewall/system/keepalivedRules/:keepalived': {
+    audited: true,
+  },
+  'DELETE /fwclouds/:fwcloud/firewalls/:firewall/system/keepalivedRules/bulkRemove': {
+    audited: true,
+  },
+  'DELETE /fwclouds/:fwcloud/snapshots/:snapshot': { audited: true },
+  'DELETE /profile/tfa/setup': { audited: true },
+  'POST /auditlogarchives': { audited: true },
+  'POST /backups': { audited: true },
+  'POST /backups/:backup/restore': { audited: true },
+  'POST /backups/import': { audited: true },
+  'POST /fwclouds': { audited: true },
+  'POST /fwclouds/:fwcloud/export': { audited: true },
+  'POST /fwclouds/:fwcloud/firewalls/:firewall/AIassistant': {
+    audited: false,
+    notes: 'Read-style operation over a mutating HTTP verb.',
+  },
+  'POST /fwclouds/:fwcloud/firewalls/:firewall/AIassistant/rules': {
+    audited: false,
+    notes: 'Read-style operation over a mutating HTTP verb.',
+  },
+  'POST /fwclouds/:fwcloud/firewalls/:firewall/ipsecs/:ipsec/installer': { audited: true },
+  'POST /fwclouds/:fwcloud/firewalls/:firewall/openvpns/:openvpn/installer': { audited: true },
+  'POST /fwclouds/:fwcloud/firewalls/:firewall/policyRules/download': {
+    audited: false,
+    notes: 'Read-style operation over a mutating HTTP verb.',
+  },
+  'POST /fwclouds/:fwcloud/firewalls/:firewall/routeGroups': { audited: true },
+  'POST /fwclouds/:fwcloud/firewalls/:firewall/routingGroups': { audited: true },
+  'POST /fwclouds/:fwcloud/firewalls/:firewall/routingRules': { audited: true },
+  'POST /fwclouds/:fwcloud/firewalls/:firewall/routingRules/copy': { audited: true },
+  'POST /fwclouds/:fwcloud/firewalls/:firewall/routingTables': { audited: true },
+  'POST /fwclouds/:fwcloud/firewalls/:firewall/routingTables/:routingTable/routes': {
+    audited: true,
+  },
+  'POST /fwclouds/:fwcloud/firewalls/:firewall/routingTables/:routingTable/routes/copy': {
+    audited: true,
+  },
+  'POST /fwclouds/:fwcloud/firewalls/:firewall/system/dhcpGroups': { audited: true },
+  'POST /fwclouds/:fwcloud/firewalls/:firewall/system/dhcpRules': { audited: true },
+  'POST /fwclouds/:fwcloud/firewalls/:firewall/system/dhcpRules/copy': { audited: true },
+  'POST /fwclouds/:fwcloud/firewalls/:firewall/system/haproxyGroups': { audited: true },
+  'POST /fwclouds/:fwcloud/firewalls/:firewall/system/haproxyRules': { audited: true },
+  'POST /fwclouds/:fwcloud/firewalls/:firewall/system/haproxyRules/copy': { audited: true },
+  'POST /fwclouds/:fwcloud/firewalls/:firewall/system/keepalivedGroups': { audited: true },
+  'POST /fwclouds/:fwcloud/firewalls/:firewall/system/keepalivedRules': { audited: true },
+  'POST /fwclouds/:fwcloud/firewalls/:firewall/system/keepalivedRules/copy': { audited: true },
+  'POST /fwclouds/:fwcloud/firewalls/:firewall/wireguards/:wireguard/installer': { audited: true },
+  'POST /fwclouds/:fwcloud/firewalls/communication/info': {
+    audited: false,
+    notes: 'Read-style operation over a mutating HTTP verb.',
+  },
+  'POST /fwclouds/:fwcloud/firewalls/communication/ping': {
+    audited: false,
+    notes: 'Read-style operation over a mutating HTTP verb.',
+  },
+  'POST /fwclouds/:fwcloud/firewalls/plugin': { audited: true },
+  'POST /fwclouds/:fwcloud/snapshots': { audited: true },
+  'POST /fwclouds/:fwcloud/snapshots/:snapshot/restore': { audited: true },
+  'POST /fwclouds/import': { audited: true },
+  'POST /openvpnarchives': { audited: true },
+  'POST /profile/tfa/setup': { audited: true },
+  'POST /profile/tfa/verify': {
+    audited: false,
+    notes: 'Read-style operation over a mutating HTTP verb.',
+  },
+  'POST /systemctl': { audited: true },
+  'POST /vpn/ipsec': { audited: true },
+  'POST /vpn/ipsec/prefix': { audited: true },
+  'POST /vpn/wireguard': { audited: true },
+  'POST /vpn/wireguard/prefix': { audited: true },
+  'PUT /aiassistant': { audited: true },
+  'PUT /auditlogarchives/config': { audited: true },
+  'PUT /auditlogs': { audited: false, notes: 'Read-style operation over a mutating HTTP verb.' },
+  'PUT /backups/config': { audited: true },
+  'PUT /fwclouds/:fwcloud': { audited: true },
+  'PUT /fwclouds/:fwcloud/cas/:ca': { audited: true },
+  'PUT /fwclouds/:fwcloud/cas/:ca/crts/:crt': { audited: true },
+  'PUT /fwclouds/:fwcloud/firewalls/:firewall/routeGroups/:routeGroup': { audited: true },
+  'PUT /fwclouds/:fwcloud/firewalls/:firewall/routingGroups/:routingGroup': { audited: true },
+  'PUT /fwclouds/:fwcloud/firewalls/:firewall/routingRules/:routingRule': { audited: true },
+  'PUT /fwclouds/:fwcloud/firewalls/:firewall/routingRules/bulkUpdate': { audited: true },
+  'PUT /fwclouds/:fwcloud/firewalls/:firewall/routingRules/move': { audited: true },
+  'PUT /fwclouds/:fwcloud/firewalls/:firewall/routingRules/moveFrom': { audited: true },
+  'PUT /fwclouds/:fwcloud/firewalls/:firewall/routingTables/:routingTable': { audited: true },
+  'PUT /fwclouds/:fwcloud/firewalls/:firewall/routingTables/:routingTable/routes/:route': {
+    audited: true,
+  },
+  'PUT /fwclouds/:fwcloud/firewalls/:firewall/routingTables/:routingTable/routes/bulkUpdate': {
+    audited: true,
+  },
+  'PUT /fwclouds/:fwcloud/firewalls/:firewall/routingTables/:routingTable/routes/move': {
+    audited: true,
+  },
+  'PUT /fwclouds/:fwcloud/firewalls/:firewall/routingTables/:routingTable/routes/moveInterface': {
+    audited: true,
+  },
+  'PUT /fwclouds/:fwcloud/firewalls/:firewall/routingTables/:routingTable/routes/moveTo': {
+    audited: true,
+  },
+  'PUT /fwclouds/:fwcloud/firewalls/:firewall/routingTables/:routingTable/routes/moveToGateway': {
+    audited: true,
+  },
+  'PUT /fwclouds/:fwcloud/firewalls/:firewall/system/dhcpGroups/:dhcpgroup': { audited: true },
+  'PUT /fwclouds/:fwcloud/firewalls/:firewall/system/dhcpRules/:dhcp': { audited: true },
+  'PUT /fwclouds/:fwcloud/firewalls/:firewall/system/dhcpRules/bulkUpdate': { audited: true },
+  'PUT /fwclouds/:fwcloud/firewalls/:firewall/system/dhcpRules/install': { audited: true },
+  'PUT /fwclouds/:fwcloud/firewalls/:firewall/system/dhcpRules/move': { audited: true },
+  'PUT /fwclouds/:fwcloud/firewalls/:firewall/system/dhcpRules/moveFrom': { audited: true },
+  'PUT /fwclouds/:fwcloud/firewalls/:firewall/system/haproxyGroups/:haproxygroup': {
+    audited: true,
+  },
+  'PUT /fwclouds/:fwcloud/firewalls/:firewall/system/haproxyRules/:haproxy': { audited: true },
+  'PUT /fwclouds/:fwcloud/firewalls/:firewall/system/haproxyRules/bulkUpdate': { audited: true },
+  'PUT /fwclouds/:fwcloud/firewalls/:firewall/system/haproxyRules/install': { audited: true },
+  'PUT /fwclouds/:fwcloud/firewalls/:firewall/system/haproxyRules/move': { audited: true },
+  'PUT /fwclouds/:fwcloud/firewalls/:firewall/system/haproxyRules/moveFrom': { audited: true },
+  'PUT /fwclouds/:fwcloud/firewalls/:firewall/system/keepalivedGroups/:keepalivedgroup': {
+    audited: true,
+  },
+  'PUT /fwclouds/:fwcloud/firewalls/:firewall/system/keepalivedRules/:keepalived': {
+    audited: true,
+  },
+  'PUT /fwclouds/:fwcloud/firewalls/:firewall/system/keepalivedRules/bulkUpdate': { audited: true },
+  'PUT /fwclouds/:fwcloud/firewalls/:firewall/system/keepalivedRules/install': { audited: true },
+  'PUT /fwclouds/:fwcloud/firewalls/:firewall/system/keepalivedRules/move': { audited: true },
+  'PUT /fwclouds/:fwcloud/firewalls/:firewall/system/keepalivedRules/moveFrom': { audited: true },
+  'PUT /fwclouds/:fwcloud/snapshots/:snapshot': { audited: true },
+  'PUT /iptables-save/export': { audited: true },
+  'PUT /iptables-save/import': { audited: true },
+  'PUT /openvpnarchives/config': { audited: true },
+  'PUT /updates/api': { audited: false, notes: 'Read-style operation over a mutating HTTP verb.' },
+  'PUT /updates/ui': { audited: false, notes: 'Read-style operation over a mutating HTTP verb.' },
+  'PUT /updates/updater': { audited: true },
+  'PUT /updates/websrv': {
+    audited: false,
+    notes: 'Read-style operation over a mutating HTTP verb.',
+  },
+  'PUT /vpn/ipsec': { audited: true },
+  'PUT /vpn/ipsec/client/options/get': {
+    audited: false,
+    notes: 'Read-style operation over a mutating HTTP verb.',
+  },
+  'PUT /vpn/ipsec/client/options/update': { audited: true },
+  'PUT /vpn/ipsec/clients/get': {
+    audited: false,
+    notes: 'Read-style operation over a mutating HTTP verb.',
+  },
+  'PUT /vpn/ipsec/config/filename': {
+    audited: false,
+    notes: 'Read-style operation over a mutating HTTP verb.',
+  },
+  'PUT /vpn/ipsec/del': { audited: true },
+  'PUT /vpn/ipsec/file/get': {
+    audited: false,
+    notes: 'Read-style operation over a mutating HTTP verb.',
+  },
+  'PUT /vpn/ipsec/get': {
+    audited: false,
+    notes: 'Read-style operation over a mutating HTTP verb.',
+  },
+  'PUT /vpn/ipsec/info/get': {
+    audited: false,
+    notes: 'Read-style operation over a mutating HTTP verb.',
+  },
+  'PUT /vpn/ipsec/install': { audited: true },
+  'PUT /vpn/ipsec/ip/get': {
+    audited: false,
+    notes: 'Read-style operation over a mutating HTTP verb.',
+  },
+  'PUT /vpn/ipsec/ipobj/get': {
+    audited: false,
+    notes: 'Read-style operation over a mutating HTTP verb.',
+  },
+  'PUT /vpn/ipsec/prefix': { audited: true },
+  'PUT /vpn/ipsec/prefix/del': { audited: true },
+  'PUT /vpn/ipsec/prefix/info/get': { audited: true },
+  'PUT /vpn/ipsec/prefix/restricted': { audited: true },
+  'PUT /vpn/ipsec/prefix/where': { audited: true },
+  'PUT /vpn/ipsec/restricted': {
+    audited: false,
+    notes: 'Read-style operation over a mutating HTTP verb.',
+  },
+  'PUT /vpn/ipsec/uninstall': { audited: true },
+  'PUT /vpn/ipsec/where': {
+    audited: false,
+    notes: 'Read-style operation over a mutating HTTP verb.',
+  },
+  'PUT /vpn/wireguard': { audited: true },
+  'PUT /vpn/wireguard/client/options/get': {
+    audited: false,
+    notes: 'Read-style operation over a mutating HTTP verb.',
+  },
+  'PUT /vpn/wireguard/client/options/update': { audited: true },
+  'PUT /vpn/wireguard/clients/get': {
+    audited: false,
+    notes: 'Read-style operation over a mutating HTTP verb.',
+  },
+  'PUT /vpn/wireguard/config/filename': {
+    audited: false,
+    notes: 'Read-style operation over a mutating HTTP verb.',
+  },
+  'PUT /vpn/wireguard/del': { audited: true },
+  'PUT /vpn/wireguard/file/get': {
+    audited: false,
+    notes: 'Read-style operation over a mutating HTTP verb.',
+  },
+  'PUT /vpn/wireguard/get': {
+    audited: false,
+    notes: 'Read-style operation over a mutating HTTP verb.',
+  },
+  'PUT /vpn/wireguard/info/get': {
+    audited: false,
+    notes: 'Read-style operation over a mutating HTTP verb.',
+  },
+  'PUT /vpn/wireguard/install': { audited: true },
+  'PUT /vpn/wireguard/ip/get': {
+    audited: false,
+    notes: 'Read-style operation over a mutating HTTP verb.',
+  },
+  'PUT /vpn/wireguard/ipobj/get': {
+    audited: false,
+    notes: 'Read-style operation over a mutating HTTP verb.',
+  },
+  'PUT /vpn/wireguard/prefix': { audited: true },
+  'PUT /vpn/wireguard/prefix/del': { audited: true },
+  'PUT /vpn/wireguard/prefix/info/get': { audited: true },
+  'PUT /vpn/wireguard/prefix/restricted': { audited: true },
+  'PUT /vpn/wireguard/prefix/where': { audited: true },
+  'PUT /vpn/wireguard/restricted': {
+    audited: false,
+    notes: 'Read-style operation over a mutating HTTP verb.',
+  },
+  'PUT /vpn/wireguard/uninstall': { audited: true },
+  'PUT /vpn/wireguard/where': {
+    audited: false,
+    notes: 'Read-style operation over a mutating HTTP verb.',
+  },
+};

--- a/tests/Unit/fonaments/http/router/audit-route-coverage.spec.ts
+++ b/tests/Unit/fonaments/http/router/audit-route-coverage.spec.ts
@@ -1,0 +1,198 @@
+/*
+    Copyright 2026 SOLTECSIS SOLUCIONES TECNOLOGICAS, SLU
+    https://soltecsis.com
+    info@soltecsis.com
+
+
+    This file is part of FWCloud (https://fwcloud.net).
+
+    FWCloud is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    FWCloud is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with FWCloud.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { expect } from 'chai';
+import { HTTPApplication } from '../../../../../src/fonaments/http-application';
+import { Route } from '../../../../../src/fonaments/http/router/route';
+import { HttpMethod, RouterService } from '../../../../../src/fonaments/http/router/router.service';
+import {
+  INTERNAL_MUTATING_ROUTE_EXCEPTIONS,
+  auditRouteExpectationManifest,
+} from './audit-expectations';
+
+type ControllerRouteIndexEntry = {
+  key: string;
+  method: HttpMethod;
+  path: string;
+  controller: string;
+  action: string;
+  name: string | null;
+};
+
+const mutatingMethods: ReadonlySet<HttpMethod> = new Set<HttpMethod>([
+  'POST',
+  'PUT',
+  'PATCH',
+  'DELETE',
+]);
+
+const nonMutatingMethods: ReadonlySet<HttpMethod> = new Set<HttpMethod>(['GET', 'HEAD', 'OPTIONS']);
+
+let cachedControllerRoutes: ControllerRouteIndexEntry[] | null = null;
+
+class RouteInspectionApplication extends HTTPApplication {
+  constructor() {
+    super(process.cwd());
+  }
+
+  protected providers(): Array<any> {
+    return [];
+  }
+
+  protected beforeMiddlewares(): Array<any> {
+    return [];
+  }
+
+  protected afterMiddlewares(): Array<any> {
+    return [];
+  }
+}
+
+const normalizePath = (pathParams: Route['pathParams']): string => {
+  const sourcePath =
+    typeof pathParams === 'string'
+      ? pathParams
+      : pathParams instanceof RegExp
+        ? pathParams.source
+        : String(pathParams);
+
+  const normalized = sourcePath
+    .replace(/:([A-Za-z0-9_]+)\([^/)]*\)/g, ':$1')
+    .replace(/\/+/g, '/')
+    .replace(/\/$/, '');
+
+  return normalized.length > 0 ? normalized : '/';
+};
+
+const formatRouteForFailure = (route: ControllerRouteIndexEntry): string => {
+  const routeName = route.name ? `, name: ${route.name}` : '';
+  return `${route.key} (${route.controller}@${route.action}${routeName})`;
+};
+
+const findDuplicateKeys = (keys: string[]): string[] => {
+  const counts = new Map<string, number>();
+
+  for (const key of keys) {
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+
+  return [...counts.entries()]
+    .filter(([, count]) => count > 1)
+    .map(([key]) => key)
+    .sort((left, right) => left.localeCompare(right));
+};
+
+const collectControllerRoutes = async (): Promise<ControllerRouteIndexEntry[]> => {
+  if (cachedControllerRoutes !== null) {
+    return cachedControllerRoutes;
+  }
+
+  const app = new RouteInspectionApplication();
+  const routerService: RouterService = await RouterService.make(app);
+  routerService.registerRoutes();
+
+  cachedControllerRoutes = routerService
+    .getRoutes()
+    .filter((route) => route.isControllerHandler())
+    .map((route) => {
+      const method = route.httpMethod;
+      const path = normalizePath(route.pathParams);
+
+      return {
+        key: `${method} ${path}`,
+        method,
+        path,
+        controller: route.controllerSignature.controller.name,
+        action: route.controllerSignature.method,
+        name: route.name ?? null,
+      };
+    })
+    .sort((left, right) => left.key.localeCompare(right.key));
+
+  return cachedControllerRoutes;
+};
+
+describe('Controller route audit expectations coverage', () => {
+  it('builds a deterministic controller route index', async () => {
+    const routes = await collectControllerRoutes();
+    const routeKeys = routes.map((route) => route.key);
+    const sortedRouteKeys = [...routeKeys].sort((left, right) => left.localeCompare(right));
+
+    expect(routes.length).to.be.greaterThan(0);
+    expect(routeKeys).to.deep.equal(sortedRouteKeys);
+
+    const duplicateRouteKeys = findDuplicateKeys(routeKeys);
+    expect(duplicateRouteKeys).to.deep.equal([]);
+  });
+
+  it('requires explicit audit expectations for mutating controller routes', async () => {
+    const routes = await collectControllerRoutes();
+    const mutatingRoutes = routes.filter(
+      (route) =>
+        mutatingMethods.has(route.method) && !INTERNAL_MUTATING_ROUTE_EXCEPTIONS.has(route.key),
+    );
+
+    const manifestKeys = Object.keys(auditRouteExpectationManifest).sort((left, right) =>
+      left.localeCompare(right),
+    );
+    const manifestKeySet = new Set(manifestKeys);
+    const runtimeMutatingRouteKeys = new Set(mutatingRoutes.map((route) => route.key));
+
+    const missingRoutes = mutatingRoutes.filter((route) => !manifestKeySet.has(route.key));
+    const staleManifestRoutes = manifestKeys.filter((key) => !runtimeMutatingRouteKeys.has(key));
+
+    if (missingRoutes.length > 0 || staleManifestRoutes.length > 0) {
+      const failureSections: string[] = [
+        'Audit expectations manifest is out of sync with mutating controller routes.',
+      ];
+
+      if (missingRoutes.length > 0) {
+        failureSections.push('Missing expectations (add these keys):');
+        failureSections.push(...missingRoutes.map((route) => `- ${formatRouteForFailure(route)}`));
+      }
+
+      if (staleManifestRoutes.length > 0) {
+        failureSections.push('Stale expectations (remove or update these keys):');
+        failureSections.push(...staleManifestRoutes.map((key) => `- ${key}`));
+      }
+
+      failureSections.push(
+        'Update tests/Unit/fonaments/http/router/audit-expectations.ts when adding or removing mutating controller routes.',
+      );
+
+      expect.fail(failureSections.join('\n'));
+    }
+  });
+
+  it('keeps non-mutating routes out of this manifest by policy', async () => {
+    const routes = await collectControllerRoutes();
+    const nonMutatingRouteKeys = new Set(
+      routes.filter((route) => nonMutatingMethods.has(route.method)).map((route) => route.key),
+    );
+
+    const expectationsForNonMutatingRoutes = Object.keys(auditRouteExpectationManifest).filter(
+      (key) => nonMutatingRouteKeys.has(key),
+    );
+
+    expect(expectationsForNonMutatingRoutes).to.deep.equal([]);
+  });
+});

--- a/tests/Unit/fonaments/http/router/audit-route-coverage.spec.ts
+++ b/tests/Unit/fonaments/http/router/audit-route-coverage.spec.ts
@@ -20,8 +20,7 @@
     along with FWCloud.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { expect } from 'chai';
-import { HTTPApplication } from '../../../../../src/fonaments/http-application';
+import { expect, testSuite } from '../../../../mocha/global-setup';
 import { Route } from '../../../../../src/fonaments/http/router/route';
 import { HttpMethod, RouterService } from '../../../../../src/fonaments/http/router/router.service';
 import {
@@ -49,21 +48,9 @@ const nonMutatingMethods: ReadonlySet<HttpMethod> = new Set<HttpMethod>(['GET', 
 
 let cachedControllerRoutes: ControllerRouteIndexEntry[] | null = null;
 
-class RouteInspectionApplication extends HTTPApplication {
-  constructor() {
-    super(process.cwd());
-  }
-
-  protected providers(): Array<any> {
-    return [];
-  }
-
-  protected beforeMiddlewares(): Array<any> {
-    return [];
-  }
-
-  protected afterMiddlewares(): Array<any> {
-    return [];
+class RouteInspectionRouterService extends RouterService {
+  public inspectControllerRoutes(): Route[] {
+    return this.parseRoutes().filter((route) => route.isControllerHandler());
   }
 }
 
@@ -106,13 +93,16 @@ const collectControllerRoutes = async (): Promise<ControllerRouteIndexEntry[]> =
     return cachedControllerRoutes;
   }
 
-  const app = new RouteInspectionApplication();
-  const routerService: RouterService = await RouterService.make(app);
-  routerService.registerRoutes();
+  if (!testSuite.app) {
+    throw new Error('Test suite application is not initialized');
+  }
+
+  const routerService: RouteInspectionRouterService = await RouteInspectionRouterService.make(
+    testSuite.app,
+  );
 
   cachedControllerRoutes = routerService
-    .getRoutes()
-    .filter((route) => route.isControllerHandler())
+    .inspectControllerRoutes()
     .map((route) => {
       const method = route.httpMethod;
       const path = normalizePath(route.pathParams);


### PR DESCRIPTION
Add a manifest-based guardrail test that enumerates runtime controller routes and fails when mutating endpoints are missing explicit audit expectations.