### PR TITLE
ADD: internal audit events for cron/worker/import and skip GET audit …

### DIFF
--- a/src/Application.ts
+++ b/src/Application.ts
@@ -87,6 +87,7 @@ import { IPSecPrefixServiceProvider } from './models/vpn/ipsec/ipsec-prefix.prov
 import { AIAssistantProvider } from './models/ai-assistant/ai-assistant.provider';
 import { AuditLogMiddleware } from './middleware/audit-log.middleware';
 import { AuditLogServiceProvider } from './models/audit/AuditLog.provider';
+import { AuditEventServiceProvider } from './models/audit/AuditEvent.provider';
 
 export class Application extends HTTPApplication {
   public static async run(path?: string): Promise<Application> {
@@ -182,6 +183,7 @@ export class Application extends HTTPApplication {
       IPSecServiceProvider,
       IPSecPrefixServiceProvider,
       AuditLogServiceProvider,
+      AuditEventServiceProvider,
     ];
   }
 

--- a/src/cli/Application.ts
+++ b/src/cli/Application.ts
@@ -37,6 +37,7 @@ import { CLIApplication } from '../fonaments/cli-application';
 import { RouterService } from '../fonaments/http/router/router.service';
 import { WireGuardServiceProvider } from '../models/vpn/wireguard/wireguard.provider';
 import { AuditLogServiceProvider } from '../models/audit/AuditLog.provider';
+import { AuditEventServiceProvider } from '../models/audit/AuditEvent.provider';
 
 export class Application extends CLIApplication {
   public static async run(path?: string): Promise<Application> {
@@ -67,6 +68,7 @@ export class Application extends CLIApplication {
       FwCloudServiceProvider,
       WireGuardServiceProvider,
       AuditLogServiceProvider,
+      AuditEventServiceProvider,
     ];
   }
 

--- a/src/fwcloud-exporter/database-importer/database-importer.ts
+++ b/src/fwcloud-exporter/database-importer/database-importer.ts
@@ -39,6 +39,7 @@ import { Worker } from 'worker_threads';
 import { InputData, OutputData } from './terraform_table.worker';
 import { ProgressNoticePayload } from '../../sockets/messages/socket-message';
 import db from '../../database/database-manager';
+import { AuditEventService } from '../../models/audit/AuditEvent.service';
 
 export class DatabaseImporter {
   protected _mapper: ImportMapping;
@@ -55,6 +56,17 @@ export class DatabaseImporter {
   }
 
   public async import(snapshot: Snapshot): Promise<FwCloud> {
+    const auditEventService: AuditEventService = await app().getService<AuditEventService>(
+      AuditEventService.name,
+    );
+    const eventId = auditEventService.startEvent({
+      source: 'importer',
+      operation: 'import',
+      entity: 'fwcloud',
+      details: {
+        snapshotPath: snapshot.path,
+      },
+    });
     const promises: Promise<any>[] = [];
     const queryRunner: QueryRunner = (
       await app().getService<DatabaseService>(DatabaseService.name)
@@ -63,80 +75,123 @@ export class DatabaseImporter {
       JSON.parse(fs.readFileSync(path.join(snapshot.path, Snapshot.DATA_FILENAME)).toString()),
     );
     let fwCloudId: number = null;
-
-    await queryRunner.startTransaction();
+    let affectedCount = 0;
 
     try {
-      await queryRunner.query('SET FOREIGN_KEY_CHECKS = 0');
+      await queryRunner.startTransaction();
 
-      this._idManager = await IdManager.make(queryRunner, data.getTableNames());
-      this._mapper = new ImportMapping(this._idManager, data);
-      let index: number = 1;
-      for (const tableName of data.getTableNames()) {
-        this.eventEmitter.emit(
-          'message',
-          new ProgressNoticePayload(`${index}/${data.getTableNames().length}`),
-        );
+      try {
+        await queryRunner.query('SET FOREIGN_KEY_CHECKS = 0');
 
-        const outputData: OutputData =
-          data.getTableResults(tableName).length === 0
-            ? {
-                result: [],
-                idMaps: this._mapper.maps,
-                idState: this._idManager.getIdState(),
-              }
-            : await this.handleTableResultTerraform(tableName, this._mapper, this._idManager, data);
+        this._idManager = await IdManager.make(queryRunner, data.getTableNames());
+        this._mapper = new ImportMapping(this._idManager, data);
+        let index: number = 1;
+        for (const tableName of data.getTableNames()) {
+          this.eventEmitter.emit(
+            'message',
+            new ProgressNoticePayload(`${index}/${data.getTableNames().length}`),
+          );
 
-        //Update mapper and id manager after worker run
-        this._mapper.maps = outputData.idMaps;
-        this._idManager = IdManager.restore(outputData.idState);
+          const outputData: OutputData =
+            data.getTableResults(tableName).length === 0
+              ? {
+                  result: [],
+                  idMaps: this._mapper.maps,
+                  idState: this._idManager.getIdState(),
+                }
+              : await this.handleTableResultTerraform(
+                  tableName,
+                  this._mapper,
+                  this._idManager,
+                  data,
+                );
 
-        // Get the data terraformed by the worker
-        const terraformedData: object[] = outputData.result;
+          //Update mapper and id manager after worker run
+          this._mapper.maps = outputData.idMaps;
+          this._idManager = IdManager.restore(outputData.idState);
 
-        if (tableName === FwCloud._getTableName()) {
-          fwCloudId = (terraformedData as any)[0].id;
+          // Get the data terraformed by the worker
+          const terraformedData: object[] = outputData.result;
+          affectedCount += terraformedData.length;
+
+          if (tableName === FwCloud._getTableName()) {
+            fwCloudId = (terraformedData as any)[0].id;
+          }
+
+          while (terraformedData.length > 0) {
+            const chunk = terraformedData.splice(0, 10000);
+            const pquery: Promise<any> = queryRunner.manager
+              .createQueryBuilder()
+              .insert()
+              .into(tableName)
+              .values(chunk)
+              .execute();
+            promises.push(pquery);
+          }
+          index++;
         }
-
-        while (terraformedData.length > 0) {
-          const chunk = terraformedData.splice(0, 10000);
-          const pquery: Promise<any> = queryRunner.manager
-            .createQueryBuilder()
-            .insert()
-            .into(tableName)
-            .values(chunk)
-            .execute();
-          promises.push(pquery);
-        }
-        index++;
+        await Promise.all(promises);
+        await queryRunner.query('SET FOREIGN_KEY_CHECKS = 1');
+        await queryRunner.commitTransaction();
+      } catch (e) {
+        await queryRunner.rollbackTransaction();
+        throw e;
+      } finally {
+        await queryRunner.release();
       }
-      await Promise.all(promises);
-      await queryRunner.query('SET FOREIGN_KEY_CHECKS = 1');
-      await queryRunner.commitTransaction();
-    } catch (e) {
-      await queryRunner.rollbackTransaction();
-      throw e;
-    } finally {
-      await queryRunner.release();
-    }
 
-    const fwCloud: FwCloud = await FwCloud.findOne({
-      where: { id: fwCloudId },
-    });
+      const fwCloud: FwCloud = await FwCloud.findOne({
+        where: { id: fwCloudId },
+      });
 
-    if (!snapshot.isHashCompatible()) {
-      await db.getSource().manager.getRepository(Firewall).update(
-        { fwCloudId: fwCloud.id },
-        {
-          install_user: null,
-          install_pass: null,
+      if (!snapshot.isHashCompatible()) {
+        const updateResult = await db.getSource().manager.getRepository(Firewall).update(
+          { fwCloudId: fwCloud.id },
+          {
+            install_user: null,
+            install_pass: null,
+          },
+        );
+        affectedCount += Math.max(0, updateResult?.affected ?? 0);
+      }
+
+      await DatabaseImporter.importDataDirectories(snapshot.path, fwCloud, this._mapper);
+
+      await auditEventService.finishEvent(eventId, {
+        affectedCount,
+        status: 'success',
+        context: {
+          fwCloudId: fwCloud.id,
+          fwCloudName: fwCloud.name,
         },
-      );
+        details: {
+          tableCount: data.getTableNames().length,
+          hashCompatible: snapshot.isHashCompatible(),
+        },
+      });
+
+      return fwCloud;
+    } catch (error) {
+      await auditEventService.finishEvent(eventId, {
+        affectedCount,
+        status: 'failed',
+        error,
+        context: fwCloudId
+          ? {
+              fwCloudId,
+            }
+          : undefined,
+        details: {
+          tableCount: data.getTableNames().length,
+          hashCompatible: snapshot.isHashCompatible(),
+        },
+      });
+      throw error;
+    } finally {
+      if (!queryRunner.isReleased) {
+        await queryRunner.release();
+      }
     }
-
-    await DatabaseImporter.importDataDirectories(snapshot.path, fwCloud, this._mapper);
-
-    return fwCloud;
   }
 
   /**

--- a/src/middleware/audit-log.middleware.ts
+++ b/src/middleware/audit-log.middleware.ts
@@ -1213,6 +1213,11 @@ export class AuditLogMiddleware extends Middleware {
       return false;
     }
 
+    const method = typeof req.method === 'string' ? req.method.toUpperCase() : 'GET';
+    if (method === 'GET' || method === 'HEAD' || method === 'OPTIONS') {
+      return false;
+    }
+
     const normalizedPath = this.normalizeRequestPath(req);
 
     if (this.isRestrictedRequest(normalizedPath)) {
@@ -1231,11 +1236,6 @@ export class AuditLogMiddleware extends Middleware {
     }
 
     if (classification === 'read') {
-      return false;
-    }
-
-    const method = typeof req.method === 'string' ? req.method.toUpperCase() : 'GET';
-    if (method === 'GET' || method === 'HEAD' || method === 'OPTIONS') {
       return false;
     }
 

--- a/src/models/audit/AuditEvent.provider.ts
+++ b/src/models/audit/AuditEvent.provider.ts
@@ -1,0 +1,34 @@
+/*!
+    Copyright 2026 SOLTECSIS SOLUCIONES TECNOLOGICAS, SLU
+    https://soltecsis.com
+    info@soltecsis.com
+
+
+    This file is part of FWCloud (https://fwcloud.net).
+
+    FWCloud is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    FWCloud is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with FWCloud.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { AbstractApplication } from '../../fonaments/abstract-application';
+import { ServiceBound, ServiceContainer } from '../../fonaments/services/service-container';
+import { ServiceProvider } from '../../fonaments/services/service-provider';
+import { AuditEventService } from './AuditEvent.service';
+
+export class AuditEventServiceProvider extends ServiceProvider {
+  public register(serviceContainer: ServiceContainer): ServiceBound {
+    return serviceContainer.singleton(AuditEventService.name, (app: AbstractApplication) => {
+      return AuditEventService.make(app);
+    });
+  }
+}

--- a/src/models/audit/AuditEvent.service.ts
+++ b/src/models/audit/AuditEvent.service.ts
@@ -1,0 +1,301 @@
+/*!
+    Copyright 2026 SOLTECSIS SOLUCIONES TECNOLOGICAS, SLU
+    https://soltecsis.com
+    info@soltecsis.com
+
+
+    This file is part of FWCloud (https://fwcloud.net).
+
+    FWCloud is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    FWCloud is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with FWCloud.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { randomUUID } from 'crypto';
+import { logger } from '../../fonaments/abstract-application';
+import { Service } from '../../fonaments/services/service';
+import { AuditLog } from './AuditLog';
+import { AuditLogService } from './AuditLog.service';
+
+export type AuditEventSource = 'cron' | 'worker' | 'importer';
+export type AuditEventOperation = 'archive' | 'retention' | 'import' | 'sync' | 'cleanup';
+export type AuditEventStatus = 'success' | 'failed';
+
+export type AuditEventContext = {
+  userId?: number | null;
+  userName?: string | null;
+  sessionId?: number | null;
+  sourceIp?: string | null;
+  fwCloudId?: number | null;
+  fwCloudName?: string | null;
+  firewallId?: number | null;
+  firewallName?: string | null;
+  clusterId?: number | null;
+  clusterName?: string | null;
+};
+
+export type StartAuditEventInput = {
+  source: AuditEventSource;
+  operation: AuditEventOperation;
+  entity: string;
+  context?: AuditEventContext;
+  details?: Record<string, unknown>;
+};
+
+export type FinishAuditEventInput = {
+  affectedCount: number;
+  status: AuditEventStatus;
+  error?: unknown;
+  finishedAt?: Date | string;
+  context?: AuditEventContext;
+  details?: Record<string, unknown>;
+};
+
+export type EmitAuditEventInput = StartAuditEventInput &
+  FinishAuditEventInput & {
+    startedAt: Date | string;
+  };
+
+type RunningAuditEvent = StartAuditEventInput & {
+  startedAt: Date;
+};
+
+const MAX_ERROR_LENGTH = 1024;
+// Internal events do not carry a request user; store them under a system identity.
+const DEFAULT_SYSTEM_USER_NAME = 'system';
+
+export class AuditEventService extends Service {
+  private _auditLogService: AuditLogService;
+  private readonly _runningEvents = new Map<string, RunningAuditEvent>();
+
+  public async build(): Promise<AuditEventService> {
+    this._auditLogService = await this._app.getService<AuditLogService>(AuditLogService.name);
+    return this;
+  }
+
+  public startEvent(input: StartAuditEventInput): string {
+    const eventId = randomUUID();
+
+    this._runningEvents.set(eventId, {
+      ...input,
+      entity: this.normalizeEntity(input.entity),
+      startedAt: new Date(),
+      context: this.normalizeContext(input.context),
+      details: this.normalizeDetails(input.details),
+    });
+
+    return eventId;
+  }
+
+  public async finishEvent(
+    eventId: string,
+    input: FinishAuditEventInput,
+  ): Promise<AuditLog | null> {
+    const runningEvent = this._runningEvents.get(eventId);
+
+    if (!runningEvent) {
+      logger()?.warn(`AuditEventService.finishEvent called with unknown eventId=${eventId}`);
+      return null;
+    }
+
+    this._runningEvents.delete(eventId);
+
+    try {
+      return await this.emitEvent({
+        source: runningEvent.source,
+        operation: runningEvent.operation,
+        entity: runningEvent.entity,
+        startedAt: runningEvent.startedAt,
+        affectedCount: input.affectedCount,
+        status: input.status,
+        error: input.error,
+        finishedAt: input.finishedAt,
+        context: this.mergeContexts(runningEvent.context, input.context),
+        details: this.mergeDetails(runningEvent.details, input.details),
+      });
+    } catch (error) {
+      logger()?.error(
+        `Unexpected error while finishing audit event ${eventId}: ${error?.message ?? error}`,
+      );
+      return null;
+    }
+  }
+
+  public async emitEvent(input: EmitAuditEventInput): Promise<AuditLog | null> {
+    const source = input.source;
+    const operation = input.operation;
+    const entity = this.normalizeEntity(input.entity);
+    const startedAt = this.normalizeDate(input.startedAt, new Date());
+    const finishedAt = this.normalizeDate(input.finishedAt, new Date());
+    const normalizedFinishedAt = finishedAt >= startedAt ? finishedAt : startedAt;
+    const status = input.status;
+    const affectedCount = this.normalizeAffectedCount(input.affectedCount);
+    const error =
+      status === 'failed' ? (this.sanitizeError(input.error) ?? 'Unknown internal error') : null;
+    const details = this.normalizeDetails(input.details);
+    const context = this.normalizeContext(input.context);
+
+    const payload = {
+      source,
+      operation,
+      entity,
+      affectedCount,
+      startedAt: startedAt.toISOString(),
+      finishedAt: normalizedFinishedAt.toISOString(),
+      status,
+      error,
+      details,
+    };
+
+    return this._auditLogService.logMutation({
+      call: `INTERNAL:${source}:${operation}`,
+      description: this.buildDescription(payload),
+      data: payload,
+      userId: context.userId ?? null,
+      userName: context.userName ?? DEFAULT_SYSTEM_USER_NAME,
+      sessionId: context.sessionId ?? null,
+      sourceIp: context.sourceIp ?? null,
+      fwCloudId: context.fwCloudId ?? null,
+      fwCloudName: context.fwCloudName ?? null,
+      firewallId: context.firewallId ?? null,
+      firewallName: context.firewallName ?? null,
+      clusterId: context.clusterId ?? null,
+      clusterName: context.clusterName ?? null,
+    });
+  }
+
+  protected normalizeEntity(entity: string): string {
+    const normalized = typeof entity === 'string' ? entity.trim() : '';
+    return normalized.length > 0 ? normalized : 'unknown';
+  }
+
+  protected normalizeDate(value: Date | string | undefined, fallback: Date): Date {
+    if (value instanceof Date && !Number.isNaN(value.getTime())) {
+      return value;
+    }
+
+    if (typeof value === 'string' && value.trim() !== '') {
+      const parsed = new Date(value);
+
+      if (!Number.isNaN(parsed.getTime())) {
+        return parsed;
+      }
+    }
+
+    return fallback;
+  }
+
+  protected normalizeAffectedCount(affectedCount: unknown): number {
+    let numeric = Number.NaN;
+
+    if (typeof affectedCount === 'number') {
+      numeric = affectedCount;
+    } else if (typeof affectedCount === 'string' && affectedCount.trim() !== '') {
+      numeric = Number.parseInt(affectedCount, 10);
+    } else if (typeof affectedCount === 'bigint') {
+      numeric = Number(affectedCount);
+    }
+
+    if (!Number.isFinite(numeric)) {
+      return 0;
+    }
+
+    return Math.max(0, Math.trunc(numeric));
+  }
+
+  protected normalizeContext(context: AuditEventContext | undefined): AuditEventContext {
+    return { ...(context ?? {}) };
+  }
+
+  protected normalizeDetails(
+    details: Record<string, unknown> | undefined,
+  ): Record<string, unknown> | null {
+    if (!details || typeof details !== 'object') {
+      return null;
+    }
+
+    return { ...details };
+  }
+
+  protected mergeContexts(
+    base: AuditEventContext | undefined,
+    input: AuditEventContext | undefined,
+  ): AuditEventContext {
+    return {
+      ...(base ?? {}),
+      ...(input ?? {}),
+    };
+  }
+
+  protected mergeDetails(
+    base: Record<string, unknown> | null | undefined,
+    input: Record<string, unknown> | undefined,
+  ): Record<string, unknown> | null {
+    const normalizedInput = this.normalizeDetails(input);
+    if (!base && !normalizedInput) {
+      return null;
+    }
+
+    return {
+      ...(base ?? {}),
+      ...(normalizedInput ?? {}),
+    };
+  }
+
+  protected sanitizeError(error: unknown): string | null {
+    if (error === null || error === undefined) {
+      return null;
+    }
+
+    let raw = '';
+
+    if (typeof error === 'string') {
+      raw = error;
+    } else if (error instanceof Error) {
+      raw = error.message;
+    } else if (
+      typeof error === 'number' ||
+      typeof error === 'boolean' ||
+      typeof error === 'bigint'
+    ) {
+      raw = String(error);
+    } else {
+      try {
+        raw = JSON.stringify(error);
+      } catch {
+        raw = '';
+      }
+    }
+
+    const normalized = raw.replace(/\s+/g, ' ').trim();
+
+    if (!normalized) {
+      return null;
+    }
+
+    if (normalized.length <= MAX_ERROR_LENGTH) {
+      return normalized;
+    }
+
+    return `${normalized.substring(0, MAX_ERROR_LENGTH - 3)}...`;
+  }
+
+  protected buildDescription(payload: {
+    source: AuditEventSource;
+    operation: AuditEventOperation;
+    entity: string;
+    affectedCount: number;
+    status: AuditEventStatus;
+  }): string {
+    return `${payload.source} ${payload.operation} on ${payload.entity} | status=${payload.status} | affected=${payload.affectedCount}`;
+  }
+}

--- a/src/models/vpn/openvpn/openvpn.service.ts
+++ b/src/models/vpn/openvpn/openvpn.service.ts
@@ -42,7 +42,7 @@ import { Zip } from '../../../utils/zip';
 import ObjectHelpers from '../../../utils/object-helpers';
 import { Mutex, tryAcquire, E_ALREADY_LOCKED } from 'async-mutex';
 import { EventEmitter } from 'events';
-import { AuditLogService } from '../../audit/AuditLog.service';
+import { AuditEventService } from '../../audit/AuditEvent.service';
 
 export type OpenVPNConfig = {
   history: {
@@ -64,7 +64,7 @@ export type OpenVPNUpdateableConfig = {
 export class OpenVPNService extends Service {
   protected _config: OpenVPNConfig;
   protected _cronService: CronService;
-  protected _auditLogService: AuditLogService;
+  protected _auditEventService: AuditEventService;
 
   protected _scheduledHistoryArchiveJob: CronJob;
   protected _scheduledRetentionJob: CronJob;
@@ -74,7 +74,7 @@ export class OpenVPNService extends Service {
   public async build(): Promise<OpenVPNService> {
     this._config = this.loadCustomizedConfig(this._app.config.get('openvpn'));
     this._cronService = await this._app.getService<CronService>(CronService.name);
-    this._auditLogService = await this._app.getService<AuditLogService>(AuditLogService.name);
+    this._auditEventService = await this._app.getService<AuditEventService>(AuditEventService.name);
 
     const archiveDirectory: string = this._config.history.data_dir;
 
@@ -90,7 +90,14 @@ export class OpenVPNService extends Service {
       this._config.history.archive_schedule,
       async () => {
         await this._archiveMutex.waitForUnlock();
-        const startedAt = Date.now();
+        const eventId = this._auditEventService.startEvent({
+          source: 'cron',
+          operation: 'archive',
+          entity: 'openvpn_status_history',
+          details: {
+            schedule: this._config.history.archive_schedule,
+          },
+        });
 
         try {
           logger().info('Starting OpenVPNHistory archive job.');
@@ -98,29 +105,16 @@ export class OpenVPNService extends Service {
           logger().info(
             `OpenVPNHistory archive job completed: ${removedItemsCount} rows archived.`,
           );
-          await this._auditLogService.logMutation({
-            call: 'CRON openvpn.history.archive',
-            description: `cron=openvpn.history.archive | status=success | rows=${removedItemsCount}`,
-            data: {
-              source: 'cron',
-              task: 'openvpn.history.archive',
-              rowsArchived: removedItemsCount,
-              schedule: this._config.history.archive_schedule,
-              durationMs: Date.now() - startedAt,
-            },
+          await this._auditEventService.finishEvent(eventId, {
+            affectedCount: removedItemsCount,
+            status: 'success',
           });
         } catch (error) {
           logger().error('OpenVPNHistory archive job ERROR: ', error.message);
-          await this._auditLogService.logMutation({
-            call: 'CRON openvpn.history.archive',
-            description: 'cron=openvpn.history.archive | status=error',
-            data: {
-              source: 'cron',
-              task: 'openvpn.history.archive',
-              schedule: this._config.history.archive_schedule,
-              durationMs: Date.now() - startedAt,
-              error: error?.message ?? String(error),
-            },
+          await this._auditEventService.finishEvent(eventId, {
+            affectedCount: 0,
+            status: 'failed',
+            error,
           });
         }
       },

--- a/src/models/vpn/openvpn/status/worker.ts
+++ b/src/models/vpn/openvpn/status/worker.ts
@@ -5,18 +5,27 @@ import db from '../../../../database/database-manager';
 import { Firewall, FirewallInstallCommunication } from '../../../firewall/Firewall';
 import { OpenVPN } from '../OpenVPN';
 import { OpenVPNOption } from '../openvpn-option.model';
-import { AuditLogService } from '../../../audit/AuditLog.service';
+import { AuditEventService, AuditEventStatus } from '../../../audit/AuditEvent.service';
 import {
   CreateOpenVPNStatusHistoryData,
   OpenVPNStatusHistoryService,
 } from './openvpn-status-history.service';
 
 async function iterate(application: Application): Promise<void> {
+  let auditEventService: AuditEventService | null = null;
+  let eventId: string | null = null;
+  let persistedRows = 0;
+
   try {
     const service: OpenVPNStatusHistoryService = await application.getService(
       OpenVPNStatusHistoryService.name,
     );
-    const auditLogService: AuditLogService = await application.getService(AuditLogService.name);
+    auditEventService = await application.getService(AuditEventService.name);
+    eventId = auditEventService.startEvent({
+      source: 'worker',
+      operation: 'sync',
+      entity: 'openvpn_status_history',
+    });
 
     // List of all OpenVPN servers with which we have to communicate.
     const openvpns: OpenVPN[] = await db
@@ -35,7 +44,6 @@ async function iterate(application: Application): Promise<void> {
     let attemptedServers = 0;
     let processedServers = 0;
     let fetchedRows = 0;
-    let persistedRows = 0;
     const failedServers: number[] = [];
 
     for (const openvpn of openvpns) {
@@ -92,22 +100,31 @@ async function iterate(application: Application): Promise<void> {
       }
     }
 
-    if (persistedRows > 0 || failedServers.length > 0) {
-      await auditLogService.logMutation({
-        call: 'WORKER openvpn.status.sync',
-        description: `worker=openvpn.status.sync | processed=${processedServers} | persisted=${persistedRows}`,
-        data: {
-          source: 'worker',
-          task: 'openvpn.status.sync',
-          attemptedServers,
-          processedServers,
-          failedServers,
-          fetchedRows,
-          persistedRows,
-        },
+    const status: AuditEventStatus = failedServers.length > 0 ? 'failed' : 'success';
+    await auditEventService.finishEvent(eventId, {
+      affectedCount: persistedRows,
+      status,
+      error:
+        failedServers.length > 0
+          ? `OpenVPN status sync failed for server IDs: ${failedServers.join(', ')}`
+          : null,
+      details: {
+        attemptedServers,
+        processedServers,
+        failedServers,
+        fetchedRows,
+        persistedRows,
+      },
+    });
+  } catch (error) {
+    if (auditEventService && eventId) {
+      await auditEventService.finishEvent(eventId, {
+        affectedCount: persistedRows,
+        status: 'failed',
+        error,
       });
     }
-  } catch (error) {
+
     application.logger().error(`WorkerError: ${error.message}`);
   }
 }

--- a/tests/Unit/fwcloud-exporter/importer/importer.spec.ts
+++ b/tests/Unit/fwcloud-exporter/importer/importer.spec.ts
@@ -30,6 +30,8 @@ import { Snapshot } from '../../../../src/snapshots/snapshot';
 import { SnapshotService } from '../../../../src/snapshots/snapshot.service';
 import { Firewall } from '../../../../src/models/firewall/Firewall';
 import StringHelper from '../../../../src/utils/string.helper';
+import { AuditLog } from '../../../../src/models/audit/AuditLog';
+import db from '../../../../src/database/database-manager';
 
 describe(describeName('Importer tests'), () => {
   let snapshotService: SnapshotService;
@@ -63,6 +65,20 @@ describe(describeName('Importer tests'), () => {
       const snapshot: Snapshot = await Snapshot.create(snapshotService.config.data_dir, fwCloud);
 
       await snapshot.restore();
+
+      const auditEvent = await db
+        .getSource()
+        .manager.getRepository(AuditLog)
+        .findOne({
+          where: { call: 'INTERNAL:importer:import' },
+          order: { id: 'DESC' },
+        });
+
+      expect(auditEvent).to.not.be.null;
+      const payload = JSON.parse(auditEvent.data);
+      expect(payload.source).to.equal('importer');
+      expect(payload.operation).to.equal('import');
+      expect(payload.status).to.equal('success');
 
       const newFwCloud: FwCloud = await FwCloud.findOne({
         where: { name: fwCloud.name },

--- a/tests/Unit/middleware/audit-log.middleware.spec.ts
+++ b/tests/Unit/middleware/audit-log.middleware.spec.ts
@@ -512,6 +512,18 @@ describe('AuditLogMiddleware', () => {
       await expectNoAuditLogs();
     });
 
+    it('should skip audit logging for GET endpoints with mutation-like path tokens', async () => {
+      const app = createNetworkObjectApp();
+
+      app.get('/profile/tfa/setup', (_req, res) => {
+        res.status(200).json({ enabled: true });
+      });
+
+      await request(app).get('/profile/tfa/setup');
+
+      await expectNoAuditLogs();
+    });
+
     it('should skip audit logging for read-only PUT endpoints', async () => {
       const app = createNetworkObjectApp();
 

--- a/tests/Unit/models/audit/audit-event.service.spec.ts
+++ b/tests/Unit/models/audit/audit-event.service.spec.ts
@@ -1,0 +1,115 @@
+/*!
+    Copyright 2026 SOLTECSIS SOLUCIONES TECNOLOGICAS, SLU
+    https://soltecsis.com
+    info@soltecsis.com
+
+
+    This file is part of FWCloud (https://fwcloud.net).
+
+    FWCloud is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    FWCloud is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with FWCloud.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { describeName, expect, testSuite } from '../../../mocha/global-setup';
+import { AuditEventService } from '../../../../src/models/audit/AuditEvent.service';
+import { AuditLog } from '../../../../src/models/audit/AuditLog';
+import db from '../../../../src/database/database-manager';
+
+describe(describeName('AuditEventService unit suite'), () => {
+  let service: AuditEventService;
+
+  beforeEach(async () => {
+    service = await testSuite.app.getService<AuditEventService>(AuditEventService.name);
+    await db.getSource().manager.getRepository(AuditLog).createQueryBuilder().delete().execute();
+  });
+
+  it('emits a success event with the required structured payload fields', async () => {
+    const eventId = service.startEvent({
+      source: 'cron',
+      operation: 'cleanup',
+      entity: 'audit_logs',
+      details: {
+        job: 'audit-log-retention',
+      },
+    });
+
+    const created = await service.finishEvent(eventId, {
+      affectedCount: 14,
+      status: 'success',
+    });
+
+    expect(created).to.not.be.null;
+
+    const persisted = await db
+      .getSource()
+      .manager.getRepository(AuditLog)
+      .findOneOrFail({ where: { id: created.id } });
+
+    const payload = JSON.parse(persisted.data);
+
+    expect(persisted.call).to.equal('INTERNAL:cron:cleanup');
+    expect(persisted.userName).to.equal('system');
+
+    expect(payload.source).to.equal('cron');
+    expect(payload.operation).to.equal('cleanup');
+    expect(payload.entity).to.equal('audit_logs');
+    expect(payload.affectedCount).to.equal(14);
+    expect(payload.status).to.equal('success');
+    expect(payload.error).to.equal(null);
+
+    expect(payload).to.have.property('startedAt');
+    expect(payload).to.have.property('finishedAt');
+    expect(Number.isNaN(new Date(payload.startedAt).getTime())).to.be.false;
+    expect(Number.isNaN(new Date(payload.finishedAt).getTime())).to.be.false;
+  });
+
+  it('emits a failed event and persists contextual identifiers', async () => {
+    const eventId = service.startEvent({
+      source: 'worker',
+      operation: 'sync',
+      entity: 'openvpn_status_history',
+      context: {
+        fwCloudId: 700,
+        firewallId: 22,
+      },
+    });
+
+    const created = await service.finishEvent(eventId, {
+      affectedCount: 3,
+      status: 'failed',
+      error: new Error(`sync failed ${'x'.repeat(2048)}`),
+      context: {
+        fwCloudName: 'edge-fwc',
+      },
+    });
+
+    expect(created).to.not.be.null;
+
+    const persisted = await db
+      .getSource()
+      .manager.getRepository(AuditLog)
+      .findOneOrFail({ where: { id: created.id } });
+
+    const payload = JSON.parse(persisted.data);
+
+    expect(persisted.call).to.equal('INTERNAL:worker:sync');
+    expect(persisted.fwCloudId).to.equal(700);
+    expect(persisted.fwCloudName).to.equal('edge-fwc');
+    expect(persisted.firewallId).to.equal(22);
+
+    expect(payload.status).to.equal('failed');
+    expect(payload.error).to.be.a('string');
+    expect(payload.error.length).to.be.at.most(1024);
+    expect(payload.error).to.not.contain('Error:');
+  });
+});


### PR DESCRIPTION
…logging

Introduce AuditEventService and provider, integrate it into OpenVPN worker/cron and importer flows, register it in app containers, add tests for success/failure persistence, and prevent false-positive audit entries for GET/HEAD/OPTIONS routes.