### PR TITLE
UPDATE: audit OpenVPN worker iterations with summarized internal events

### DIFF
--- a/src/models/vpn/openvpn/status/openvpn-status-history.service.ts
+++ b/src/models/vpn/openvpn/status/openvpn-status-history.service.ts
@@ -14,6 +14,12 @@ export type CreateOpenVPNStatusHistoryData = {
   disconnectedAtTimestampInSeconds?: number;
 };
 
+export type CreateOpenVPNStatusHistorySummary = {
+  entries: OpenVPNStatusHistory[];
+  insertedEntries: number;
+  updatedDisconnections: number;
+};
+
 export type FindOpenVPNStatusHistoryOptions = {
   rangeTimestamp?: [Date, Date];
   name?: string;
@@ -70,6 +76,21 @@ export class OpenVPNStatusHistoryService extends Service {
     serverOpenVPNId: number,
     data: CreateOpenVPNStatusHistoryData[],
   ): Promise<OpenVPNStatusHistory[]> {
+    const result = await this.createWithSummary(serverOpenVPNId, data);
+    return result.entries;
+  }
+
+  /**
+   * Creates and persists a batch while returning synchronization counters.
+   *
+   * @param serverOpenVPNId
+   * @param data
+   * @returns
+   */
+  async createWithSummary(
+    serverOpenVPNId: number,
+    data: CreateOpenVPNStatusHistoryData[],
+  ): Promise<CreateOpenVPNStatusHistorySummary> {
     // Makes sure openvpn is a server
     const serverOpenVPN: OpenVPN = await db
       .getSource()
@@ -108,10 +129,16 @@ export class OpenVPNStatusHistoryService extends Service {
     }
 
     // If the data is empty, then detect disconnections and returns.
+    let updatedDisconnections = 0;
+
     if (data.length === 0) {
       // In this case, all previous connections will be set as disconnected.
-      await this.detectDisconnections([], lastTimestampedBatch);
-      return [];
+      updatedDisconnections += await this.detectDisconnections([], lastTimestampedBatch);
+      return {
+        entries: [],
+        insertedEntries: 0,
+        updatedDisconnections,
+      };
     }
 
     // Get the timestamps of the records to be persisted
@@ -126,7 +153,10 @@ export class OpenVPNStatusHistoryService extends Service {
       const timestampedBatch: CreateOpenVPNStatusHistoryData[] = data.filter(
         (item) => item.timestampInSeconds === timestamp,
       );
-      await this.detectDisconnections(timestampedBatch, lastTimestampedBatch);
+      updatedDisconnections += await this.detectDisconnections(
+        timestampedBatch,
+        lastTimestampedBatch,
+      );
 
       const persistedBatch = await db
         .getSource()
@@ -151,7 +181,11 @@ export class OpenVPNStatusHistoryService extends Service {
 
       entries = entries.concat(lastTimestampedBatch);
     }
-    return entries;
+    return {
+      entries,
+      insertedEntries: entries.length,
+      updatedDisconnections,
+    };
   }
 
   /**
@@ -365,7 +399,9 @@ export class OpenVPNStatusHistoryService extends Service {
   protected async detectDisconnections(
     newTimestampedBatch: CreateOpenVPNStatusHistoryData[],
     previousTimestampedBatch: OpenVPNStatusHistory[],
-  ): Promise<void> {
+  ): Promise<number> {
+    let updatedDisconnections = 0;
+
     // If the current batch doesn't have an entry which exists on the previous batch,
     // then we must add an entry to the batch with a disconnectedAt value
     for (const previous of previousTimestampedBatch.filter(
@@ -378,14 +414,18 @@ export class OpenVPNStatusHistoryService extends Service {
       if (matchIndex < 0) {
         previous.disconnectedAtTimestampInSeconds = previous.timestampInSeconds;
         await db.getSource().manager.getRepository(OpenVPNStatusHistory).save(previous);
+        updatedDisconnections++;
       } else {
         // If the persisted batch name is present in the current batch but its address is different,
         // then is a new connection.
         if (previous.address !== newTimestampedBatch[matchIndex].address) {
           previous.disconnectedAtTimestampInSeconds = previous.timestampInSeconds;
           await db.getSource().manager.getRepository(OpenVPNStatusHistory).save(previous);
+          updatedDisconnections++;
         }
       }
     }
+
+    return updatedDisconnections;
   }
 }

--- a/src/models/vpn/openvpn/status/worker.ts
+++ b/src/models/vpn/openvpn/status/worker.ts
@@ -8,27 +8,22 @@ import { OpenVPNOption } from '../openvpn-option.model';
 import { AuditEventService, AuditEventStatus } from '../../../audit/AuditEvent.service';
 import {
   CreateOpenVPNStatusHistoryData,
+  CreateOpenVPNStatusHistorySummary,
   OpenVPNStatusHistoryService,
 } from './openvpn-status-history.service';
 
-async function iterate(application: Application): Promise<void> {
-  let auditEventService: AuditEventService | null = null;
-  let eventId: string | null = null;
-  let persistedRows = 0;
+const AUDIT_ENTITY = 'OpenVPNStatusHistory';
 
-  try {
-    const service: OpenVPNStatusHistoryService = await application.getService(
-      OpenVPNStatusHistoryService.name,
-    );
-    auditEventService = await application.getService(AuditEventService.name);
-    eventId = auditEventService.startEvent({
-      source: 'worker',
-      operation: 'sync',
-      entity: 'openvpn_status_history',
-    });
+export type OpenVPNStatusWorkerIterationDependencies = {
+  getOpenVPNServers: () => Promise<OpenVPN[]>;
+  getClusterFirewalls: (clusterId: number) => Promise<Firewall[]>;
+  getStatusOption: (openVPNId: number) => Promise<OpenVPNOption | null>;
+};
 
+const defaultDependencies: OpenVPNStatusWorkerIterationDependencies = {
+  getOpenVPNServers: async (): Promise<OpenVPN[]> => {
     // List of all OpenVPN servers with which we have to communicate.
-    const openvpns: OpenVPN[] = await db
+    return db
       .getSource()
       .getRepository(OpenVPN)
       .createQueryBuilder('openvpn')
@@ -40,25 +35,99 @@ async function iterate(application: Application): Promise<void> {
         communication: FirewallInstallCommunication.Agent,
       })
       .getMany();
+  },
+  getClusterFirewalls: async (clusterId: number): Promise<Firewall[]> => {
+    return db
+      .getSource()
+      .getRepository(Firewall)
+      .createQueryBuilder('firewall')
+      .where('firewall.clusterId = :cluster', { cluster: clusterId })
+      .andWhere('firewall.install_communication = :communication', {
+        communication: FirewallInstallCommunication.Agent,
+      })
+      .getMany();
+  },
+  getStatusOption: async (openVPNId: number): Promise<OpenVPNOption | null> => {
+    const option = await OpenVPN.getOptData(db.getQuery(), openVPNId, 'status');
+    return (option as OpenVPNOption) ?? null;
+  },
+};
 
-    let attemptedServers = 0;
-    let processedServers = 0;
-    let fetchedRows = 0;
-    const failedServers: number[] = [];
+type WorkerIterationSummary = {
+  processedOpenvpns: number;
+  insertedEntries: number;
+  updatedDisconnections: number;
+  errorsCount: number;
+};
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  if (error === null || error === undefined) {
+    return 'Unknown error';
+  }
+
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return 'Unserializable error object';
+  }
+}
+
+function buildRecoverableErrorSummary(messages: string[]): string | null {
+  if (messages.length === 0) {
+    return null;
+  }
+
+  if (messages.length === 1) {
+    return messages[0];
+  }
+
+  return `${messages[0]} (+${messages.length - 1} more errors)`;
+}
+
+export async function iterate(
+  application: Application,
+  dependencies: OpenVPNStatusWorkerIterationDependencies = defaultDependencies,
+): Promise<void> {
+  let auditEventService: AuditEventService | null = null;
+  let eventId: string | null = null;
+  const startedAt = new Date();
+  let finishedAt: Date = startedAt;
+  let status: AuditEventStatus = 'success';
+  let errorSummary: string | null = null;
+  const recoverableErrors: string[] = [];
+  const summary: WorkerIterationSummary = {
+    processedOpenvpns: 0,
+    insertedEntries: 0,
+    updatedDisconnections: 0,
+    errorsCount: 0,
+  };
+
+  try {
+    auditEventService = await application.getService(AuditEventService.name);
+    eventId = auditEventService.startEvent({
+      source: 'worker',
+      operation: 'sync',
+      entity: AUDIT_ENTITY,
+    });
+    const service: OpenVPNStatusHistoryService = await application.getService(
+      OpenVPNStatusHistoryService.name,
+    );
+
+    const openvpns: OpenVPN[] = await dependencies.getOpenVPNServers();
 
     for (const openvpn of openvpns) {
-      attemptedServers++;
+      summary.processedOpenvpns++;
       try {
         const firewalls: Firewall[] = openvpn.firewall.clusterId
-          ? await db
-              .getSource()
-              .getRepository(Firewall)
-              .createQueryBuilder('firewall')
-              .where('firewall.clusterId = :cluster', { cluster: openvpn.firewall.clusterId })
-              .andWhere('firewall.install_communication = :communication', {
-                communication: FirewallInstallCommunication.Agent,
-              })
-              .getMany()
+          ? await dependencies.getClusterFirewalls(openvpn.firewall.clusterId)
           : [openvpn.firewall];
 
         let entries: CreateOpenVPNStatusHistoryData[] = [];
@@ -66,11 +135,7 @@ async function iterate(application: Application): Promise<void> {
           const communication: AgentCommunication =
             (await firewall.getCommunication()) as AgentCommunication;
 
-          const statusOption: OpenVPNOption = (await OpenVPN.getOptData(
-            db.getQuery(),
-            openvpn.id,
-            'status',
-          )) as OpenVPNOption;
+          const statusOption: OpenVPNOption | null = await dependencies.getStatusOption(openvpn.id);
 
           if (statusOption) {
             const data: OpenVPNHistoryRecord[] = await communication.getOpenVPNHistoryFile(
@@ -90,46 +155,55 @@ async function iterate(application: Application): Promise<void> {
           }
         }
 
-        const persistedEntries = await service.create(openvpn.id, entries);
-        processedServers++;
-        fetchedRows += entries.length;
-        persistedRows += persistedEntries.length;
+        const persistedEntries: CreateOpenVPNStatusHistorySummary = await service.createWithSummary(
+          openvpn.id,
+          entries,
+        );
+        summary.insertedEntries += persistedEntries.insertedEntries;
+        summary.updatedDisconnections += persistedEntries.updatedDisconnections;
       } catch (error) {
-        failedServers.push(openvpn.id);
-        application.logger().error(`WorkerError: OpenVPN ${openvpn.id} failed: ${error.message}`);
+        summary.errorsCount++;
+        const errorMessage = getErrorMessage(error);
+        recoverableErrors.push(`OpenVPN ${openvpn.id}: ${errorMessage}`);
+        application.logger().error(`WorkerError: OpenVPN ${openvpn.id} failed: ${errorMessage}`);
       }
     }
-
-    const status: AuditEventStatus = failedServers.length > 0 ? 'failed' : 'success';
-    await auditEventService.finishEvent(eventId, {
-      affectedCount: persistedRows,
-      status,
-      error:
-        failedServers.length > 0
-          ? `OpenVPN status sync failed for server IDs: ${failedServers.join(', ')}`
-          : null,
-      details: {
-        attemptedServers,
-        processedServers,
-        failedServers,
-        fetchedRows,
-        persistedRows,
-      },
-    });
   } catch (error) {
-    if (auditEventService && eventId) {
-      await auditEventService.finishEvent(eventId, {
-        affectedCount: persistedRows,
-        status: 'failed',
-        error,
-      });
+    status = 'failed';
+    errorSummary = getErrorMessage(error);
+    application.logger().error(`WorkerError: ${errorSummary}`);
+  } finally {
+    finishedAt = new Date();
+
+    if (status === 'success') {
+      errorSummary = buildRecoverableErrorSummary(recoverableErrors);
     }
 
-    application.logger().error(`WorkerError: ${error.message}`);
+    if (auditEventService && eventId) {
+      await auditEventService.finishEvent(eventId, {
+        affectedCount: summary.insertedEntries,
+        status,
+        error: status === 'failed' ? errorSummary : null,
+        finishedAt,
+        details: {
+          source: 'worker',
+          operation: 'sync',
+          entity: AUDIT_ENTITY,
+          processedOpenvpns: summary.processedOpenvpns,
+          insertedEntries: summary.insertedEntries,
+          updatedDisconnections: summary.updatedDisconnections,
+          errorsCount: summary.errorsCount,
+          startedAt: startedAt.toISOString(),
+          finishedAt: finishedAt.toISOString(),
+          status,
+          error: errorSummary,
+        },
+      });
+    }
   }
 }
 
-async function waitUntilNextIteration(ms: number): Promise<void> {
+export async function waitUntilNextIteration(ms: number): Promise<void> {
   return new Promise<void>((resolve) => {
     if (ms <= 0) {
       return resolve();
@@ -141,7 +215,7 @@ async function waitUntilNextIteration(ms: number): Promise<void> {
   });
 }
 
-async function work(): Promise<void> {
+export async function work(): Promise<void> {
   const application = await Application.run();
   const interval: number = application.config.get('openvpn.agent.history.interval');
 
@@ -161,9 +235,11 @@ async function work(): Promise<void> {
   }
 }
 
-work()
-  .then(() => {})
-  .catch((error) => {
-    console.error(error);
-    throw error;
-  });
+if (require.main === module) {
+  work()
+    .then(() => {})
+    .catch((error) => {
+      console.error(error);
+      throw error;
+    });
+}

--- a/tests/Unit/models/vpn/openvpn/status/worker.spec.ts
+++ b/tests/Unit/models/vpn/openvpn/status/worker.spec.ts
@@ -1,0 +1,235 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+import { OpenVPNHistoryRecord } from '../../../../../../src/communications/communication';
+import { AuditEventService } from '../../../../../../src/models/audit/AuditEvent.service';
+import {
+  OpenVPNStatusHistoryService,
+  CreateOpenVPNStatusHistorySummary,
+} from '../../../../../../src/models/vpn/openvpn/status/openvpn-status-history.service';
+import {
+  iterate,
+  OpenVPNStatusWorkerIterationDependencies,
+} from '../../../../../../src/models/vpn/openvpn/status/worker';
+import { OpenVPN } from '../../../../../../src/models/vpn/openvpn/OpenVPN';
+import { Firewall } from '../../../../../../src/models/firewall/Firewall';
+
+function buildApplication(
+  auditService: Pick<AuditEventService, 'startEvent' | 'finishEvent'>,
+  historyService: Pick<OpenVPNStatusHistoryService, 'createWithSummary'>,
+  loggerError: sinon.SinonStub,
+): any {
+  const getService = sinon.stub();
+  getService.withArgs(AuditEventService.name).resolves(auditService);
+  getService.withArgs(OpenVPNStatusHistoryService.name).resolves(historyService);
+
+  return {
+    getService,
+    logger: () => ({
+      error: loggerError,
+      info: sinon.stub(),
+      debug: sinon.stub(),
+    }),
+  };
+}
+
+function buildOpenVPN(id: number, firewall: Firewall): OpenVPN {
+  return {
+    id,
+    firewall,
+  } as unknown as OpenVPN;
+}
+
+function buildFirewall(records: OpenVPNHistoryRecord[]): Firewall {
+  return {
+    clusterId: null,
+    getCommunication: async () => {
+      return {
+        getOpenVPNHistoryFile: async () => records,
+      };
+    },
+  } as unknown as Firewall;
+}
+
+describe('OpenVPN status worker iteration audit events', () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('emits one successful event with non-zero counters', async () => {
+    const loggerError = sandbox.stub();
+    const startEvent = sandbox.stub().returns('event-id');
+    const finishEvent = sandbox.stub().resolves(null);
+    const createWithSummary = sandbox.stub().resolves({
+      entries: [],
+      insertedEntries: 3,
+      updatedDisconnections: 2,
+    } as CreateOpenVPNStatusHistorySummary);
+
+    const dependencies: OpenVPNStatusWorkerIterationDependencies = {
+      getOpenVPNServers: async () => [
+        buildOpenVPN(
+          10,
+          buildFirewall([
+            {
+              timestamp: 10,
+              name: 'alice',
+              address: '10.0.0.2',
+              bytesReceived: 100,
+              bytesSent: 200,
+              connectedAtTimestampInSeconds: 1,
+            },
+          ]),
+        ),
+      ],
+      getClusterFirewalls: async () => [],
+      getStatusOption: async () => ({ arg: '/tmp/status' }) as any,
+    };
+
+    await iterate(
+      buildApplication(
+        { startEvent, finishEvent } as Pick<AuditEventService, 'startEvent' | 'finishEvent'>,
+        {
+          createWithSummary,
+        } as Pick<OpenVPNStatusHistoryService, 'createWithSummary'>,
+        loggerError,
+      ),
+      dependencies,
+    );
+
+    expect(startEvent.callCount).to.equal(1);
+    expect(finishEvent.callCount).to.equal(1);
+    expect(createWithSummary.callCount).to.equal(1);
+
+    expect(startEvent.firstCall.args[0]).to.deep.include({
+      source: 'worker',
+      operation: 'sync',
+      entity: 'OpenVPNStatusHistory',
+    });
+
+    const finishPayload = finishEvent.firstCall.args[1];
+    expect(finishPayload.status).to.equal('success');
+    expect(finishPayload.affectedCount).to.equal(3);
+    expect(finishPayload.details.processedOpenvpns).to.equal(1);
+    expect(finishPayload.details.insertedEntries).to.equal(3);
+    expect(finishPayload.details.updatedDisconnections).to.equal(2);
+    expect(finishPayload.details.errorsCount).to.equal(0);
+    expect(finishPayload.details.error).to.equal(null);
+    expect(loggerError.callCount).to.equal(0);
+  });
+
+  it('keeps status success with recoverable per-openvpn errors', async () => {
+    const loggerError = sandbox.stub();
+    const startEvent = sandbox.stub().returns('event-id');
+    const finishEvent = sandbox.stub().resolves(null);
+    const createWithSummary = sandbox.stub();
+    createWithSummary.onFirstCall().rejects(new Error('sync item failed'));
+    createWithSummary.onSecondCall().resolves({
+      entries: [],
+      insertedEntries: 5,
+      updatedDisconnections: 1,
+    } as CreateOpenVPNStatusHistorySummary);
+
+    const dependencies: OpenVPNStatusWorkerIterationDependencies = {
+      getOpenVPNServers: async () => [
+        buildOpenVPN(
+          10,
+          buildFirewall([
+            {
+              timestamp: 10,
+              name: 'alice',
+              address: '10.0.0.2',
+              bytesReceived: 100,
+              bytesSent: 200,
+              connectedAtTimestampInSeconds: 1,
+            },
+          ]),
+        ),
+        buildOpenVPN(
+          11,
+          buildFirewall([
+            {
+              timestamp: 11,
+              name: 'bob',
+              address: '10.0.0.3',
+              bytesReceived: 110,
+              bytesSent: 210,
+              connectedAtTimestampInSeconds: 2,
+            },
+          ]),
+        ),
+      ],
+      getClusterFirewalls: async () => [],
+      getStatusOption: async () => ({ arg: '/tmp/status' }) as any,
+    };
+
+    await iterate(
+      buildApplication(
+        { startEvent, finishEvent } as Pick<AuditEventService, 'startEvent' | 'finishEvent'>,
+        {
+          createWithSummary,
+        } as Pick<OpenVPNStatusHistoryService, 'createWithSummary'>,
+        loggerError,
+      ),
+      dependencies,
+    );
+
+    expect(startEvent.callCount).to.equal(1);
+    expect(finishEvent.callCount).to.equal(1);
+    expect(createWithSummary.callCount).to.equal(2);
+
+    const finishPayload = finishEvent.firstCall.args[1];
+    expect(finishPayload.status).to.equal('success');
+    expect(finishPayload.error).to.equal(null);
+    expect(finishPayload.affectedCount).to.equal(5);
+    expect(finishPayload.details.processedOpenvpns).to.equal(2);
+    expect(finishPayload.details.insertedEntries).to.equal(5);
+    expect(finishPayload.details.updatedDisconnections).to.equal(1);
+    expect(finishPayload.details.errorsCount).to.equal(1);
+    expect(finishPayload.details.error).to.contain('OpenVPN 10: sync item failed');
+    expect(loggerError.callCount).to.equal(1);
+  });
+
+  it('emits status failed when the iteration aborts with a hard error', async () => {
+    const loggerError = sandbox.stub();
+    const startEvent = sandbox.stub().returns('event-id');
+    const finishEvent = sandbox.stub().resolves(null);
+    const createWithSummary = sandbox.stub();
+
+    const dependencies: OpenVPNStatusWorkerIterationDependencies = {
+      getOpenVPNServers: async () => {
+        throw new Error('hard failure');
+      },
+      getClusterFirewalls: async () => [],
+      getStatusOption: async () => ({ arg: '/tmp/status' }) as any,
+    };
+
+    await iterate(
+      buildApplication(
+        { startEvent, finishEvent } as Pick<AuditEventService, 'startEvent' | 'finishEvent'>,
+        {
+          createWithSummary,
+        } as Pick<OpenVPNStatusHistoryService, 'createWithSummary'>,
+        loggerError,
+      ),
+      dependencies,
+    );
+
+    expect(startEvent.callCount).to.equal(1);
+    expect(finishEvent.callCount).to.equal(1);
+    expect(createWithSummary.callCount).to.equal(0);
+
+    const finishPayload = finishEvent.firstCall.args[1];
+    expect(finishPayload.status).to.equal('failed');
+    expect(finishPayload.error).to.equal('hard failure');
+    expect(finishPayload.details.status).to.equal('failed');
+    expect(finishPayload.details.error).to.equal('hard failure');
+    expect(finishPayload.details.errorsCount).to.equal(0);
+    expect(loggerError.callCount).to.equal(1);
+  });
+});


### PR DESCRIPTION
Add one internal audit event per OpenVPN status worker iteration with timing and counters.

Expose createWithSummary() to report inserted entries and updated disconnections.

Add unit coverage for success, recoverable per-item errors, and hard-failure iterations.