### PR TITLE
UPDATE: Add configurable internal audit toggles, gate internal event …

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -448,6 +448,38 @@ const config = convict({
   },
 
   auditLogs: {
+    internal: {
+      enabled: {
+        doc: 'Enable persistence of internal audit events (workers, cron jobs and importers).',
+        format: Boolean,
+        default: false,
+        env: 'AUDIT_LOG_INTERNAL_ENABLED'
+      },
+      cron: {
+        enabled: {
+          doc: 'Enable persistence of internal cron audit events.',
+          format: Boolean,
+          default: false,
+          env: 'AUDIT_LOG_INTERNAL_CRON_ENABLED'
+        }
+      },
+      worker: {
+        enabled: {
+          doc: 'Enable persistence of internal worker audit events.',
+          format: Boolean,
+          default: false,
+          env: 'AUDIT_LOG_INTERNAL_WORKER_ENABLED'
+        }
+      },
+      importer: {
+        enabled: {
+          doc: 'Enable persistence of internal importer audit events.',
+          format: Boolean,
+          default: false,
+          env: 'AUDIT_LOG_INTERNAL_IMPORTER_ENABLED'
+        }
+      }
+    },
     archive: {
       data_dir: {
         doc: 'Directory for storing audit log archive files.',

--- a/src/controllers/fwclouds/fwcloud.controller.ts
+++ b/src/controllers/fwclouds/fwcloud.controller.ts
@@ -103,6 +103,24 @@ export class FwCloudController extends Controller {
       availablecommunications = ['agent', 'ssh'];
     }
 
-    return ResponseBuilder.buildResponse().status(200).body({ availablecommunications });
+    return ResponseBuilder.buildResponse()
+      .status(200)
+      .body({
+        availablecommunications,
+        auditLogs: {
+          internal: {
+            enabled: this._app.config.get('auditLogs.internal.enabled'),
+            cron: {
+              enabled: this._app.config.get('auditLogs.internal.cron.enabled'),
+            },
+            worker: {
+              enabled: this._app.config.get('auditLogs.internal.worker.enabled'),
+            },
+            importer: {
+              enabled: this._app.config.get('auditLogs.internal.importer.enabled'),
+            },
+          },
+        },
+      });
   }
 }

--- a/src/models/audit/AuditEvent.service.ts
+++ b/src/models/audit/AuditEvent.service.ts
@@ -69,7 +69,19 @@ type RunningAuditEvent = StartAuditEventInput & {
   startedAt: Date;
 };
 
+type InternalAuditSourceConfig = {
+  enabled?: boolean;
+};
+
+type InternalAuditConfig = {
+  enabled?: boolean;
+  cron?: InternalAuditSourceConfig;
+  worker?: InternalAuditSourceConfig;
+  importer?: InternalAuditSourceConfig;
+};
+
 const MAX_ERROR_LENGTH = 1024;
+const INTERNAL_AUDIT_DISABLED_EVENT_PREFIX = '__disabled_internal_audit__';
 // Internal events do not carry a request user; store them under a system identity.
 const DEFAULT_SYSTEM_USER_NAME = 'system';
 
@@ -83,6 +95,10 @@ export class AuditEventService extends Service {
   }
 
   public startEvent(input: StartAuditEventInput): string {
+    if (!this.isInternalAuditEnabledForSource(input.source)) {
+      return this.buildDisabledEventId();
+    }
+
     const eventId = randomUUID();
 
     this._runningEvents.set(eventId, {
@@ -100,6 +116,10 @@ export class AuditEventService extends Service {
     eventId: string,
     input: FinishAuditEventInput,
   ): Promise<AuditLog | null> {
+    if (this.isDisabledEventId(eventId)) {
+      return null;
+    }
+
     const runningEvent = this._runningEvents.get(eventId);
 
     if (!runningEvent) {
@@ -132,6 +152,11 @@ export class AuditEventService extends Service {
 
   public async emitEvent(input: EmitAuditEventInput): Promise<AuditLog | null> {
     const source = input.source;
+
+    if (!this.isInternalAuditEnabledForSource(source)) {
+      return null;
+    }
+
     const operation = input.operation;
     const entity = this.normalizeEntity(input.entity);
     const startedAt = this.normalizeDate(input.startedAt, new Date());
@@ -297,5 +322,31 @@ export class AuditEventService extends Service {
     status: AuditEventStatus;
   }): string {
     return `${payload.source} ${payload.operation} on ${payload.entity} | status=${payload.status} | affected=${payload.affectedCount}`;
+  }
+
+  protected isInternalAuditEnabledForSource(source: AuditEventSource): boolean {
+    const config = this.readInternalAuditConfig();
+
+    if (config.enabled === false) {
+      return false;
+    }
+
+    if (config[source]?.enabled === false) {
+      return false;
+    }
+
+    return true;
+  }
+
+  protected readInternalAuditConfig(): InternalAuditConfig {
+    return (this._app.config.get('auditLogs.internal') ?? {}) as InternalAuditConfig;
+  }
+
+  protected buildDisabledEventId(): string {
+    return `${INTERNAL_AUDIT_DISABLED_EVENT_PREFIX}${randomUUID()}`;
+  }
+
+  protected isDisabledEventId(eventId: string): boolean {
+    return eventId.startsWith(INTERNAL_AUDIT_DISABLED_EVENT_PREFIX);
   }
 }

--- a/tests/Unit/fwcloud-exporter/importer/importer.spec.ts
+++ b/tests/Unit/fwcloud-exporter/importer/importer.spec.ts
@@ -53,10 +53,21 @@ type ImportAuditPayload = {
 
 describe(describeName('Importer tests'), () => {
   let snapshotService: SnapshotService;
+  const setInternalAuditConfig = (enabled: boolean): void => {
+    testSuite.app.config.set('auditLogs.internal.enabled', enabled);
+    testSuite.app.config.set('auditLogs.internal.cron.enabled', enabled);
+    testSuite.app.config.set('auditLogs.internal.worker.enabled', enabled);
+    testSuite.app.config.set('auditLogs.internal.importer.enabled', enabled);
+  };
 
   beforeEach(async () => {
+    setInternalAuditConfig(true);
     snapshotService = await testSuite.app.getService<SnapshotService>(SnapshotService.name);
     await db.getSource().manager.getRepository(AuditLog).createQueryBuilder().delete().execute();
+  });
+
+  afterEach(() => {
+    setInternalAuditConfig(false);
   });
 
   async function getImportAuditPayloads(): Promise<ImportAuditPayload[]> {

--- a/tests/Unit/models/audit/audit-event.service.spec.ts
+++ b/tests/Unit/models/audit/audit-event.service.spec.ts
@@ -27,10 +27,21 @@ import db from '../../../../src/database/database-manager';
 
 describe(describeName('AuditEventService unit suite'), () => {
   let service: AuditEventService;
+  const restoreInternalAuditConfig = (): void => {
+    testSuite.app.config.set('auditLogs.internal.enabled', true);
+    testSuite.app.config.set('auditLogs.internal.cron.enabled', true);
+    testSuite.app.config.set('auditLogs.internal.worker.enabled', true);
+    testSuite.app.config.set('auditLogs.internal.importer.enabled', true);
+  };
 
   beforeEach(async () => {
+    restoreInternalAuditConfig();
     service = await testSuite.app.getService<AuditEventService>(AuditEventService.name);
     await db.getSource().manager.getRepository(AuditLog).createQueryBuilder().delete().execute();
+  });
+
+  afterEach(() => {
+    restoreInternalAuditConfig();
   });
 
   it('emits a success event with the required structured payload fields', async () => {
@@ -111,5 +122,65 @@ describe(describeName('AuditEventService unit suite'), () => {
     expect(payload.error).to.be.a('string');
     expect(payload.error.length).to.be.at.most(1024);
     expect(payload.error).to.not.contain('Error:');
+  });
+
+  it('does not persist internal events when global internal auditing is disabled', async () => {
+    testSuite.app.config.set('auditLogs.internal.enabled', false);
+
+    const eventId = service.startEvent({
+      source: 'cron',
+      operation: 'cleanup',
+      entity: 'audit_logs',
+    });
+
+    const created = await service.finishEvent(eventId, {
+      affectedCount: 5,
+      status: 'success',
+    });
+
+    const persistedCount = await db.getSource().manager.getRepository(AuditLog).count();
+
+    expect(created).to.equal(null);
+    expect(persistedCount).to.equal(0);
+  });
+
+  it('supports per-source internal audit toggles', async () => {
+    testSuite.app.config.set('auditLogs.internal.worker.enabled', false);
+
+    const workerEventId = service.startEvent({
+      source: 'worker',
+      operation: 'sync',
+      entity: 'openvpn_status_history',
+    });
+
+    const workerCreated = await service.finishEvent(workerEventId, {
+      affectedCount: 7,
+      status: 'success',
+    });
+
+    const cronEventId = service.startEvent({
+      source: 'cron',
+      operation: 'cleanup',
+      entity: 'audit_logs',
+    });
+
+    const cronCreated = await service.finishEvent(cronEventId, {
+      affectedCount: 2,
+      status: 'success',
+    });
+
+    const persistedEntries = await db
+      .getSource()
+      .manager.getRepository(AuditLog)
+      .find({
+        order: {
+          id: 'ASC',
+        },
+      });
+
+    expect(workerCreated).to.equal(null);
+    expect(cronCreated).to.not.equal(null);
+    expect(persistedEntries).to.have.length(1);
+    expect(persistedEntries[0].call).to.equal('INTERNAL:cron:cleanup');
   });
 });


### PR DESCRIPTION
…persistence by source, expose current settings in /config, and cover enabled/disabled behavior with tests.